### PR TITLE
Work on the transcription and Provisional edition

### DIFF
--- a/gayadasa/cul-add-2491_nyayacandrika_sarirasthana-4.txt
+++ b/gayadasa/cul-add-2491_nyayacandrika_sarirasthana-4.txt
@@ -69,19 +69,9 @@
 
         <revisionDesc>
             <change when="2026-08-02" who="Dominik Wujastyk">Changed the filename</change>
-            <change when="2026-08-04" who="Andrey Klebanov">xml:id="NC.3.4.94-99 <list>
-                    <item>Work on the header.</item>
-                    <item>Copied the source description from
-                        cul-add-2491_nyayacandrika-sarirasthana-1.txt.</item>
-                    <item>Standardized the numbering and classification of textual divisions.</item>
-                    <item>Proofread and corrected NC 3.4.1--3.</item>
-                </list>
-            </change>
-            <change when="2026-08-07" who="Andrey Klebanov">xml:id="NC.3.4.94-99 <list>
-                    <item>Added "ana"-values to pb-s.</item>
-                    <item>Proofread and corrected NC 3.4.4--.</item>
-                </list>
-            </change>
+            <change when="2026-08-04" who="Andrey Klebanov">Header and proofreading of NC 3.4.1--3. </change>
+            <change when="2026-08-11" who="Andrey Klebanov">Proofread until 3.4.5, aligned 3.4.1a
+                with the provisional edition.</change>
         </revisionDesc>
 
     </teiHeader>
@@ -92,62 +82,69 @@
 
                 <div n="4" type="adhyāya">
 
-                    <!--<milestone n="33r9" unit="folio" facs="MS-image-name.jpg"/>-->
+                    <!--<milestone n="33r9" unit="folio" facs="MS-ADD-02491-000-00041.jpg"/>-->
 
-                    <p xml:id="NC.3.4.1">
-                        <lb n="9"/>garbhāvakrāṃtiśārī<lb n="10"/>rānaṃtaraṃ
-                        garbhavyākaraṇasyocitatvāt | vyākaraṇaṃ vi<subst><del>ka</del><add
-                                place="below">va</add></subst>raṇaṃ | tat śukraśoṇitaṃ
-                        garbhāśayagataṃ prāṇi<mod type="subst" rend="added-vowel-stroke"
-                                ><del>na</del><add place="inline">nā</add></mod>ṃ garbhaḥ|| </p>
+                    <lg xml:id="NC.3.4.1a">
+                        <l><lb n="9"/>garbhāvakrāṃtiśārī<lb n="10"/>rānaṃtaraṃ
+                            garbhavyākaraṇasyocitatvāt | vyākaraṇaṃ vi<subst><del>ka</del><add
+                                    place="below">va</add></subst>raṇaṃ | tat śukraśoṇitaṃ
+                            garbhāśayagataṃ prāṇi<mod type="subst" rend="added-vowel-stroke"
+                                    ><del>na</del><add place="inline">nā</add></mod>ṃ garbhaḥ||</l>
+                    </lg>
 
-                    <p xml:id="NC.3.4.3">
-                        <pb ana="MS-ADD-02491-000-00042.jpg" n="33v"/><lb n="1"/>tacca prāṇa/ na
-                        yeṣām eva bhāvānām anvayavyatirekābhyāṃ anvayavyatireki ca teṣv eva
-                        prīṇābhyāṃ paribhāṣayann āha ||<lb n="2"/><subst><del
-                                rend="enclosed-in-square-brackets">agniroma ity ādi</del><add
-                                place="left-margin">agnīṣoma ity ādi ||<metamark
-                                    function="insertion">2</metamark></add></subst> kutaḥ punar ādāv
-                        evāgniḥ somādi prāṇavyākaraṇam ucyate | anaṃtaroktād
-                            garbhapratyaṃgaguṇāgaṇa<lb n="3"/>vat teṣāṃm apy agnīṣomādīnāṃ
-                        dharmmādharmmābhyām eva saṃyogayo<add place="above">ḥ</add> kṛ<add
-                            place="above">ta</add>tvāt | tad evaṃ pāribhāṣikāmaś ca teṣu darśayituṃ
-                            śabdapu|<lb n="4"/>rovarttinām ivaiteṣāṃ prāṇaśabdo prayoge varttayati |
-                        manasiś ceti cakāra eṣām api śarīraguṇadoṣāṇām iva dharmmā<lb n="5"/>dharmma
-                        nimittatvaṃ samuccayāya | tatrānilajalānilabhūtānāṃ agnisomamarutāṃ
-                        devatārūpeṇādhiṣṭhitā doṣāḥ | ya<lb n="6"/>d āha || svayaṃbhūr eṣa bhavān
-                        vāyur ity abhiśabditaḥ | <!-- SS 2.1.5cd --> tathā sthityutpattivināśeṣu
-                        bhūtānām eṣa kāraṇam iti <!-- 2.1.7ab -->|| tathā<lb n="7"/>hy udāryo
-                        bhaṃgavān agniḥ pācako 'nnasyahīśvaraḥ | <!-- cf. 1.35.27 --> tathā soma eva
-                        >bhagavān śarīrāṃtargata āpyāyam iti iti | ta ete<lb n="8"/>svābhāvena
-                        praṇayaṃtīti prāṇaḥ | śārīrā doṣā vātādayaḥ | tadaivaiteṣāṃ dhātutvam api
-                        dadhatīti kṛtvā tathā manodo<lb n="9"/>ṣāḥ satvādīni trīṇi
-                        parasparopastaṃbhād ekībhūya prakṛtibhūtāni | praṇayaṃtīti prāṇāḥ |
-                        paṃceṃdriyāṇi karmmajāni<lb n="10"/> cakṣurādīni rūpādigrahaṇakarmmaṇā
-                        prāṇayaṃti | evaṃ bhūtātmā kmmapuruṣo 'pi || aśeṣasyaiva karmmarāśe
-                            caitanya<pb ana="MS-ADD-02491-000-00043.jpg" n="34r"/><lb n="1"
-                        />heturiti | prāṇayaṃti na tu ca cetanādhātur eva prāṇanaṃ bhūtānāṃ vakṣyati
-                        hi | tad eva cetanāvasthitam iti | atra hi ṣaḍ<lb n="2"/>hetuka eva puruṣo
-                        'dhikṛta iti satvādīnāṃ pṛthak nirdeśo nāsti | agniṣomānilāś ca tatra
-                            bhūtagrahaṇenaiva<lb n="3"/> gṛhyaṃte | cetanāgrahaṇeṃdriyāṇi sāmarthyād
-                        āpannasamanaso 'vyatirekeṇa satvādīni ucyaṃte | tatra punareṣāṃ<lb n="4"
-                        />caitanye pṛthakgrahaṇena cetanādhātutvaṃ bādhitaṃ | yathā naiṣāṃ
-                                ce<subst><del>tu</del><add place="above"
-                        >ta</add></subst>nādhātusamatvaṃ yathā pratyekakarmmanirdeśo<lb n="5"
-                        />svayam evācāryo vakṣyati | evaṃ mano'pi bhūtātmanaḥ
-                        śarīrāṃtagrahaṇamokṣaṇahetur iti tadapi prāṇayati ||<lb n="6"/> tad eva
-                        sarva eva pratyekaṃ prāṇayaṃtīti | samudāyo py eṣāṃ vyavahāro lāghavārthaḥ
-                        paribhāṣitaḥ | jaḍas tu bhūtātma<lb n="7"/>śabdena na mano abhidhatte |
-                        manograhaṇaṃ nādhīyate | tanna bhūtātmamanasor vyaktabhedāt | eṣāṃ ca
-                        prāṇatvaṃ pratyekaṃ<lb n="8"/>marmmanirddeśa eva pratipāditaṃ bhavam iti |
-                        bhavati cātra | cittavātādisatvādibhūtātmeṃdriyapaṃcake | prāṇākhyaṃ<lb
-                            n="9"/>paryabhāṣī sma puraskṛtadvācatinā garbhasā kevalaṃ
-                        vāṃgapratyaṃgeṣu guṇāḥ | dharmmādharmmātmakāṃ prāṇeṣv api cetat sa<lb n="10"
-                        />mucitaṃ | prāṇeṣv api | agnīṣomīyatvāt garbhasya prathamam agnīṣomo
-                        nirddiṣṭo | tatrāṣṭādhārādheyayor ādhā<pb ana="MS-ADD-02491-000-00044.jpg"
-                            n="34v"/><lb n="1"/>rasya prāgbhāvāttu ārttavaprāgbhāvenāgneḥ
-                        pūrvanirddeśo 'lpācatvārapūrvanipātena anaṃtaram agnīṣomādi | trayo<lb n="2"
-                        />daśamāvidhaḥ | </p>
+                    <lg xml:id="NC.3.4.3a">
+                        <l>
+                            <pb ana="MS-ADD-02491-000-00042.jpg" n="33v"/><lb n="1"/>tacca prāṇa/ na
+                            yeṣām eva bhāvānām anvayavyatirekābhyāṃ anvayavyatireki ca teṣv eva
+                            prīṇābhyāṃ paribhāṣayann āha ||<lb n="2"/><subst><del
+                                    rend="enclosed-in-square-brackets">agniroma ity ādi</del><add
+                                    place="left-margin">agnīṣoma ity ādi ||<metamark
+                                        function="insertion">2</metamark></add></subst></l>
+                    </lg>
+                    <lg xml:id="NC.3.4.3b">
+                        <l>kutaḥ punar ādāv evāgniḥ somādi prāṇavyākaraṇam ucyate | anaṃtaroktād
+                                garbhapratyaṃgaguṇāgaṇa<lb n="3"/>vat teṣāṃm apy agnīṣomādīnāṃ
+                            dharmmādharmmābhyām eva saṃyogayo<add place="above">ḥ</add> kṛ<add
+                                place="above">ta</add>tvāt | tad evaṃ pāribhāṣikāmaś ca teṣu
+                            darśayituṃ śabdapu|<lb n="4"/>rovarttinām ivaiteṣāṃ prāṇaśabdo prayoge
+                            varttayati | manasiś ceti cakāra eṣām api śarīraguṇadoṣāṇām iva
+                                dharmmā<lb n="5"/>dharmma nimittatvaṃ samuccayāya |
+                            tatrānilajalānilabhūtānāṃ agnisomamarutāṃ devatārūpeṇādhiṣṭhitā doṣāḥ |
+                                ya<lb n="6"/>d āha || svayaṃbhūr eṣa bhavān vāyur ity abhiśabditaḥ |
+                            <!-- SS 2.1.5cd --> tathā sthityutpattivināśeṣu bhūtānām eṣa kāraṇam iti
+                            <!-- 2.1.7ab -->|| tathā<lb n="7"/>hy udāryo bhaṃgavān agniḥ pācako
+                            'nnasyahīśvaraḥ | <!-- cf. 1.35.27 --> tathā soma eva >bhagavān
+                            śarīrāṃtargata āpyāyam iti iti | ta ete<lb n="8"/>svābhāvena
+                            praṇayaṃtīti prāṇaḥ | śārīrā doṣā vātādayaḥ | tadaivaiteṣāṃ dhātutvam
+                            api dadhatīti kṛtvā tathā manodo<lb n="9"/>ṣāḥ satvādīni trīṇi
+                            parasparopastaṃbhād ekībhūya prakṛtibhūtāni | praṇayaṃtīti prāṇāḥ |
+                            paṃceṃdriyāṇi karmmajāni<lb n="10"/> cakṣurādīni rūpādigrahaṇakarmmaṇā
+                            prāṇayaṃti | evaṃ bhūtātmā kmmapuruṣo 'pi || aśeṣasyaiva karmmarāśe
+                                caitanya<pb ana="MS-ADD-02491-000-00043.jpg" n="34r"/><lb n="1"
+                            />heturiti | prāṇayaṃti na tu ca cetanādhātur eva prāṇanaṃ bhūtānāṃ
+                            vakṣyati hi | tad eva cetanāvasthitam iti | atra hi ṣaḍ<lb n="2"/>hetuka
+                            eva puruṣo 'dhikṛta iti satvādīnāṃ pṛthak nirdeśo nāsti | agniṣomānilāś
+                            ca tatra bhūtagrahaṇenaiva<lb n="3"/> gṛhyaṃte | cetanāgrahaṇeṃdriyāṇi
+                            sāmarthyād āpannasamanaso 'vyatirekeṇa satvādīni ucyaṃte | tatra
+                                punareṣāṃ<lb n="4"/>caitanye pṛthakgrahaṇena cetanādhātutvaṃ
+                            bādhitaṃ | yathā naiṣāṃ ce<subst><del>tu</del><add place="above"
+                                    >ta</add></subst>nādhātusamatvaṃ yathā pratyekakarmmanirdeśo<lb
+                                n="5"/>svayam evācāryo vakṣyati | evaṃ mano'pi bhūtātmanaḥ
+                            śarīrāṃtagrahaṇamokṣaṇahetur iti tadapi prāṇayati ||<lb n="6"/> tad eva
+                            sarva eva pratyekaṃ prāṇayaṃtīti | samudāyo py eṣāṃ vyavahāro
+                            lāghavārthaḥ paribhāṣitaḥ | jaḍas tu bhūtātma<lb n="7"/>śabdena na mano
+                            abhidhatte | manograhaṇaṃ nādhīyate | tanna bhūtātmamanasor vyaktabhedāt
+                            | eṣāṃ ca prāṇatvaṃ pratyekaṃ<lb n="8"/>marmmanirddeśa eva pratipāditaṃ
+                            bhavam iti | bhavati cātra | cittavātādisatvādibhūtātmeṃdriyapaṃcake |
+                                prāṇākhyaṃ<lb n="9"/>paryabhāṣī sma puraskṛtadvācatinā garbhasā
+                            kevalaṃ vāṃgapratyaṃgeṣu guṇāḥ | dharmmādharmmātmakāṃ prāṇeṣv api cetat
+                                sa<lb n="10"/>mucitaṃ | prāṇeṣv api | agnīṣomīyatvāt garbhasya
+                            prathamam agnīṣomo nirddiṣṭo | tatrāṣṭādhārādheyayor ādhā<pb
+                                ana="MS-ADD-02491-000-00044.jpg" n="34v"/><lb n="1"/>rasya
+                            prāgbhāvāttu ārttavaprāgbhāvenāgneḥ pūrvanirddeśo
+                            'lpācatvārapūrvanipātena anaṃtaram agnīṣomādi | trayo<lb n="2"
+                            />daśamāvidhaḥ | </l>
+                    </lg>
 
                     <p xml:id="NC.3.4.4">
                         <label>NC.3.4.4</label>

--- a/gayadasa/cul-add-2491_nyayacandrika_sarirasthana-4.txt
+++ b/gayadasa/cul-add-2491_nyayacandrika_sarirasthana-4.txt
@@ -69,13 +69,17 @@
 
         <revisionDesc>
             <change when="2026-08-02" who="Dominik Wujastyk">Changed the filename</change>
-            <change when="2026-08-03" who="Andrey Klebanov">xml:id="NC.3.4.94-99
-                <list>
+            <change when="2026-08-04" who="Andrey Klebanov">xml:id="NC.3.4.94-99 <list>
                     <item>Work on the header.</item>
                     <item>Copied the source description from
                         cul-add-2491_nyayacandrika-sarirasthana-1.txt.</item>
                     <item>Standardized the numbering and classification of textual divisions.</item>
                     <item>Proofread and corrected NC 3.4.1--3.</item>
+                </list>
+            </change>
+            <change when="2026-08-07" who="Andrey Klebanov">xml:id="NC.3.4.94-99 <list>
+                    <item>Added "ana"-values to pb-s.</item>
+                    <item>Proofread and corrected NC 3.4.4--.</item>
                 </list>
             </change>
         </revisionDesc>
@@ -88,28 +92,24 @@
 
                 <div n="4" type="adhyāya">
 
-                    <milestone n="33r9" unit="folio" facs="MS-image-name.jpg"/>
-                    <!-- @@ ADD MANUSCRIPT IMAGE NAME -->
+                    <!--<milestone n="33r9" unit="folio" facs="MS-image-name.jpg"/>-->
 
                     <p xml:id="NC.3.4.1">
                         <lb n="9"/>garbhāvakrāṃtiśārī<lb n="10"/>rānaṃtaraṃ
-                        garbhavyākaraṇasyocitatvāt | vyākaraṇaṃ vi<subst>
-                            <del>ka</del>
-                            <add place="below">va</add>
-                        </subst>raṇaṃ | tat śukraśoṇitaṃ garbhāśayagataṃ prāṇi<mod type="subst"
-                            rend="added-vowel-stroke"><del>na</del><add place="inline"
-                            >nā</add></mod>ṃ garbhaḥ||
-                    </p>
+                        garbhavyākaraṇasyocitatvāt | vyākaraṇaṃ vi<subst><del>ka</del><add
+                                place="below">va</add></subst>raṇaṃ | tat śukraśoṇitaṃ
+                        garbhāśayagataṃ prāṇi<mod type="subst" rend="added-vowel-stroke"
+                                ><del>na</del><add place="inline">nā</add></mod>ṃ garbhaḥ|| </p>
 
-                    <p xml:id="NC.3.4.3a">
-                        <pb n="33v"/><lb n="1"/>tacca prāṇa/ na yeṣām eva bhāvānām
-                        anvayavyatirekābhyāṃ anvayavyatireki ca teṣv eva prīṇābhyāṃ paribhāṣayann
-                        āha ||<lb n="2"/><subst>
-                            <del rend="enclosed-in-square-brackets">agniroma ity ādi</del>
-                            <add place="left-margin">agnīṣoma ity ādi ||<metamark
-                                    function="insertion">2</metamark></add>
-                        </subst> kutaḥ punar ādāv evāgniḥ somādi prāṇavyākaraṇam ucyate |
-                        anaṃtaroktād garbhapratyaṃgaguṇāgaṇa<lb n="3"/>vat teṣāṃm apy agnīṣomādīnāṃ
+                    <p xml:id="NC.3.4.3">
+                        <pb ana="MS-ADD-02491-000-00042.jpg" n="33v"/><lb n="1"/>tacca prāṇa/ na
+                        yeṣām eva bhāvānām anvayavyatirekābhyāṃ anvayavyatireki ca teṣv eva
+                        prīṇābhyāṃ paribhāṣayann āha ||<lb n="2"/><subst><del
+                                rend="enclosed-in-square-brackets">agniroma ity ādi</del><add
+                                place="left-margin">agnīṣoma ity ādi ||<metamark
+                                    function="insertion">2</metamark></add></subst> kutaḥ punar ādāv
+                        evāgniḥ somādi prāṇavyākaraṇam ucyate | anaṃtaroktād
+                            garbhapratyaṃgaguṇāgaṇa<lb n="3"/>vat teṣāṃm apy agnīṣomādīnāṃ
                         dharmmādharmmābhyām eva saṃyogayo<add place="above">ḥ</add> kṛ<add
                             place="above">ta</add>tvāt | tad evaṃ pāribhāṣikāmaś ca teṣu darśayituṃ
                             śabdapu|<lb n="4"/>rovarttinām ivaiteṣāṃ prāṇaśabdo prayoge varttayati |
@@ -125,101 +125,107 @@
                         parasparopastaṃbhād ekībhūya prakṛtibhūtāni | praṇayaṃtīti prāṇāḥ |
                         paṃceṃdriyāṇi karmmajāni<lb n="10"/> cakṣurādīni rūpādigrahaṇakarmmaṇā
                         prāṇayaṃti | evaṃ bhūtātmā kmmapuruṣo 'pi || aśeṣasyaiva karmmarāśe
-                            caitanya<pb n="43"/>heturiti | prāṇayaṃti na tu ca cetanādhātur eva
-                        prāṇanaṃ bhūtānāṃ vakṣyati hi | tad eva cetanāvasthitam iti | atra hi ṣaḍ<lb
-                            n="2"/>hetuka eva puruṣo 'dhikṛta iti satvādīnāṃ pṛthak nirdeśo nāsti |
-                        agniṣomānilāś ca tatra bhūtagrahaṇenaiva<lb n="3"/> gṛhyaṃte |
-                        cetanāgrahaṇeṃdriyāṇi sāmarthyād āpannasamanaso 'vyatirekeṇa satvādīni
-                        ucyaṃte | tatra punareṣāṃ<lb n="4"/>caitanye pṛthakgrahaṇena cetanādhātutvaṃ
-                        bādhitaṃ | yathā naiṣāṃ ce<subst>
-                            <del>tu</del>
-                            <add place="above">ta</add>
-                        </subst>nādhātusamatvaṃ yathā pratyekakarmmanirdeśo<lb n="5"/>svayam
-                        evācāryo vakṣyati | evaṃ mano'pi bhūtātmanaḥ śarīrāṃtagrahaṇamokṣaṇahetur
-                        iti tadapi prāṇayati ||<lb n="6"/> tad eva sarva eva pratyekaṃ prāṇayaṃtīti
-                        | samudāyo py eṣāṃ vyavahāro lāghavārthaḥ paribhāṣitaḥ | jaḍas tu
-                            bhūtātma<lb n="7"/>śabdena na mano abhidhatte | manograhaṇaṃ nādhīyate |
-                        tanna bhūtātmamanasor vyaktabhedāt | eṣāṃ ca prāṇatvaṃ pratyekaṃ<lb n="8"
-                        />marmmanirddeśa eva pratipāditaṃ bhavam iti | bhavati cātra |
-                        cittavātādisatvādibhūtātmeṃdriyapaṃcake | prāṇākhyaṃ<lb n="9"/>paryabhāṣī
-                        sma puraskṛtadvācatinā garbhasā kevalaṃ vāṃgapratyaṃgeṣu guṇāḥ |
-                        dharmmādharmmātmakāṃ prāṇeṣv api cetat sa<lb n="10"/>mucitaṃ | prāṇeṣv api |
-                        agnīṣomīyatvāt garbhasya prathamam agnīṣomo nirddiṣṭo |
-                        tatrāṣṭādhārādheyayor ādhā<pb n="44"/>rasya prāgbhāvāttu
-                        ārttavaprāgbhāvenāgneḥ pūrvanirddeśo 'lpācatvārapūrvanipātena anaṃtaram
-                        agnīṣomādi | trayo<lb n="2"/>daśamāvidhaḥ | 
-                    </p>
+                            caitanya<pb ana="MS-ADD-02491-000-00043.jpg" n="34r"/><lb n="1"
+                        />heturiti | prāṇayaṃti na tu ca cetanādhātur eva prāṇanaṃ bhūtānāṃ vakṣyati
+                        hi | tad eva cetanāvasthitam iti | atra hi ṣaḍ<lb n="2"/>hetuka eva puruṣo
+                        'dhikṛta iti satvādīnāṃ pṛthak nirdeśo nāsti | agniṣomānilāś ca tatra
+                            bhūtagrahaṇenaiva<lb n="3"/> gṛhyaṃte | cetanāgrahaṇeṃdriyāṇi sāmarthyād
+                        āpannasamanaso 'vyatirekeṇa satvādīni ucyaṃte | tatra punareṣāṃ<lb n="4"
+                        />caitanye pṛthakgrahaṇena cetanādhātutvaṃ bādhitaṃ | yathā naiṣāṃ
+                                ce<subst><del>tu</del><add place="above"
+                        >ta</add></subst>nādhātusamatvaṃ yathā pratyekakarmmanirdeśo<lb n="5"
+                        />svayam evācāryo vakṣyati | evaṃ mano'pi bhūtātmanaḥ
+                        śarīrāṃtagrahaṇamokṣaṇahetur iti tadapi prāṇayati ||<lb n="6"/> tad eva
+                        sarva eva pratyekaṃ prāṇayaṃtīti | samudāyo py eṣāṃ vyavahāro lāghavārthaḥ
+                        paribhāṣitaḥ | jaḍas tu bhūtātma<lb n="7"/>śabdena na mano abhidhatte |
+                        manograhaṇaṃ nādhīyate | tanna bhūtātmamanasor vyaktabhedāt | eṣāṃ ca
+                        prāṇatvaṃ pratyekaṃ<lb n="8"/>marmmanirddeśa eva pratipāditaṃ bhavam iti |
+                        bhavati cātra | cittavātādisatvādibhūtātmeṃdriyapaṃcake | prāṇākhyaṃ<lb
+                            n="9"/>paryabhāṣī sma puraskṛtadvācatinā garbhasā kevalaṃ
+                        vāṃgapratyaṃgeṣu guṇāḥ | dharmmādharmmātmakāṃ prāṇeṣv api cetat sa<lb n="10"
+                        />mucitaṃ | prāṇeṣv api | agnīṣomīyatvāt garbhasya prathamam agnīṣomo
+                        nirddiṣṭo | tatrāṣṭādhārādheyayor ādhā<pb ana="MS-ADD-02491-000-00044.jpg"
+                            n="34v"/><lb n="1"/>rasya prāgbhāvāttu ārttavaprāgbhāvenāgneḥ
+                        pūrvanirddeśo 'lpācatvārapūrvanipātena anaṃtaram agnīṣomādi | trayo<lb n="2"
+                        />daśamāvidhaḥ | </p>
 
                     <p xml:id="NC.3.4.4">
-                        <label>NC.3.4.4</label> prāṇasadbhāva eva śukraśoṇitasya prāṇataḥ pariṇāmena
-                        tvagādi saṃbhava iti | anaṃtaraṃ tvagādi vyā<lb n="3"/>karaṇaṃ kurvvan āha |
-                        tasyā khalu śukraśoṇitasyetyādi | kṣīrasaṃtāni kāṣṭaṃ dṛṣṭāṃtena bahirvṛtti
-                            śukraśoṇita<lb n="4"/>sārārabdhatvaṃ tvacāṃ bodhayaṃti | teṣāṃ
-                        bahiḥsthitatvena pratyakṣatvāt prathamarasadhātū'dhiṣṭhānatvāc ca prathamaṃ
-                            vyāka<lb n="5"/>raṇaṃ | asāravyākaraṇaṃ vivṛṇvan āha || tāsām ity ādi |
-                        tāsām iti nirdhāraṇe ṣaṣṭhī sarvavarṇān rogādikān<lb n="6"
-                        />chāyāmahābhūtapaṃcakena kṛtā paṃcavidhā || tad uktaṃ carake || evāmādīnāṃ
-                        paṃcapaṃcānāṃ chāyāvidhilakṣaṇā a<lb n="7"/>vabhāsinī ca
-                            <unclear>mapāsyā</unclear>bhrājakānāgnikṛtaṃ paṃcavidhāṃ ca chāyām iti
-                        || carakāt prabhāpy avabhāsate | tatra chāyā <lb n="8"/>prabhavayor viśeṣaḥ
-                        | prabhāva<unclear>rtma</unclear>m ākramayati | cāyā tu
-                            <unclear>vartma</unclear>prakāśinī | āsannālakṣate chāyābhāvikaṣṭāva<lb
-                            n="9"/>lakṣyate tasyāḥ pramāṇaṃ nirddiśan āha || sā vravīhir ity ādi ||
-                        vrīhiratra yavaḥ | tānādhikārāt | yaduktaṃ ya<lb n="10"
-                            /><unclear>vāhyardvogradoṣṭa</unclear> iti || pradhānakalpanayā
-                        gṛhītatvāt śūkadhānyānāṃ nānābhedena pramāṇāniyamāc ca ||<pb n="45"/> evaṃ
-                        dvitīyādiṣv api tāsāṃ saptānām api abhipretaṃ | mānaṃ
-                            pradeśāṃta<unclear>rodi</unclear>tena saṃbaṃdhaṃ kurvvan āha ||
-                            aṃguṣṭhodara<lb n="2"/> mātra sārddhaṃ caturtha ca | carake tu
-                        kāyacikitsā siddhāṃtenaiva ṣāḍava tvacaḥ || atra śalyataṃtrasiddhāṃtena
-                            saptaiva<lb n="3"/>tvacāṃ ca yathoditaṃ mānaṃ māṃsaleṣu avakāśeṣu na
-                        punarasthipradhāneṣu lalāṭādiṣu | tad uktaṃ bhoje | māṃsale<lb n="4"/>ṣv
+                        <label>NC.3.4.4</label>
+                         prāṇasadbhāva eva śukraśoṇitasya prāṇataḥ pariṇāmena tvagādisaṃbhava iti |
+                        anaṃtaraṃ tvagādivyā<lb n="3"/>karaṇaṃ kurvvan āha | tasyā khalu
+                        śukraśoṇitasyetyādi | kṣīrasaṃtānikāṣṭaṃdṛṣṭāṃtena bahirvṛttiśukraśoṇita<lb
+                            n="4"/>sārārabdhatvaṃ tvacāṃ bodhayaṃti | teṣāṃ bahiḥsthitatvena
+                        pratyakṣatvāt prathamarasadhātū 'dhiṣṭhānatvāc ca prathamaṃ vyāka<lb n="5"
+                        />raṇaṃ | asāravyākaraṇaṃ vivṛṇvann āha || tāsām ity ādi | tāsām iti
+                        nirddhāraṇe ṣaṣṭhī sarvavarṇān
+                            rogādikān<!--rogā>gaurā (ro,gau do look very similar)--><lb n="6"/>chāyā
+                        mahābhūtapaṃcakena kṛtā paṃcavidhā || tad uktaṃ carake || evā<subst><add
+                                place="above">mā</add></subst>dīnāṃ paṃca paṃcānāṃ chāyā
+                        vidhilakṣaṇā | a<lb n="7"/>vabhāsinī camapāsyā bhrājakānāgnikṛtaṃ
+                        paṃcavidhāṃ ca chāyām iti || carakāt prabhāpy avabhāsate | tatra chāyā<lb
+                            n="8"/>prabhavayor viśeṣaḥ | prabhā varṇṇam ākramayati | chāyā tu
+                        varṇaprakāśinī | āsannā lakṣate chāyā bhā vikaṣṭāva<lb n="9"/>lakṣyate |
+                        tasyāḥ pramāṇaṃ nirddiśan āha || sā vravīhir ityādi || vrīhir atra yavaḥ |
+                        nānādhikārāt | yaduktaṃ ya<lb n="10"/>vāhyarddho gudauṣṭa iti ||
+                        <!-- SS 2.2.6 --> pradhānakalpanayā gṛhītatvāt śūkadhānyānāṃ nānābhedena
+                        pramāṇāniyamāc ca || <pb ana="MS-ADD-02491-000-00045.jpg" n="35r"/>
+                        <lb n="1"/>evaṃ dvitīyādiṣv api tāsāṃ saptānām api abhipretaṃ | mānaṃ
+                        pradeśāṃtaroditena saṃbaṃdhaṃ kurvvan āha || aṃguṣṭhodara<lb n="2"
+                        />mātrasārddhaṃ caturtha ca | carake tu kāyacikitsāsiddhāṃtenaiva ṣaḍ eva
+                        tvacaḥ ||<!-- cf. CS 4.7.4 --> atra śalyataṃtrasiddhāṃtena saptaiva <lb
+                            n="3"/>tvacāṃ ca yathoditaṃ mānaṃ māṃsaleṣu avakāśeṣu na punar
+                        asthipradhāneṣu lalāṭādiṣu | tad uktaṃ bhoje | māṃsale<lb n="4"/>ṣv
                         avakāśeṣu yathāmānaṃ tvacāṃ mataṃ | lalāṭāṃguṣṭhagaṃḍeṣu kapāleṣu
-                        tathālpikāḥ | tvacapratyāsannatvekaḥ lābhā<lb n="5"/>gaṃ nirddiśan āha || </p>
+                        tathālpikāḥ |</p>
 
                     <l xml:id="NC.3.4.5">
-                        <label>NC.3.4.5</label> kalāḥ khalvapītyādi || kalāpi saptetyarthaḥ | tāsāṃ
-                        sāmānyena lakṣaṇaṃ | saṃkṣepeṇa darśayan āha ||<lb n="6"/>
-                        dhātvāśayāṃtaramaryādāḥ dadhatīti dhātavaḥ rasaraktamāṃsādayaḥ |
-                        kaphapittapurīṣāny api svasthaṃ svakarmmaṇā dadhatī<lb n="7"/>ti kṛtvā | </l>
+                        <label>NC.3.4.5</label>
+                         tvacapratyāsannatve kalābhā<lb n="5"/>gaṃ nirddiśan āha || kalāḥ khalv
+                        apītyādi || kalāpi saptetyarthaḥ | tāsāṃ sāmānyena lakṣaṇaṃ | saṃkṣepeṇa
+                        darśayan āha ||<lb n="6"/> dhātvāśayāṃtaramaryādāḥ dadhatīti dhātavaḥ
+                        rasaraktamāṃsādayaḥ | kaphapittapurīṣāny api svasthaṃ svakarmmaṇā dadhatī<lb
+                            n="7"/>ti kṛtvā | </l>
 
                     <l xml:id="NC.3.4.6-7">
-                        <label>NC.3.4.6-7</label> tāsāṃm antasthitatvenāpratyakṣāṇām asti
-                        pratyupamānaṃ pramāṇaṃ nirddiśan āha | yathāhītyādi | etena ka<lb n="8"
-                        />lāsādhita pṛtha - - nādyupalaṃbhakāryeṇa viviktām avakalānām astitvaṃ
-                        sādhitaṃ bhavet | tāsām upaṣṭaṃbhakaṃ<lb n="9"/>nirddiśan āha || snāyubhiś
-                        ceti | ādikalābhāgāḥ kalāviśeṣāḥ bhūmibhāgavat | jarāyu ārttava <lb n="10"
+                        <label>NC.3.4.6-7</label>
+                         tāsāṃm antasthitatvenāpratyakṣāṇām asti pratyupamānaṃ pramāṇaṃ nirddiśan
+                        āha | yathāhītyādi | etena ka<lb n="8"/>lāsādhita pṛtha - -
+                        nādyupalaṃbhakāryeṇa viviktām avakalānām astitvaṃ sādhitaṃ bhavet | tāsām
+                            upaṣṭaṃbhakaṃ<lb n="9"/>nirddiśan āha || snāyubhiś ceti | ādikalābhāgāḥ
+                        kalāviśeṣāḥ bhūmibhāgavat | jarāyu ārttava <lb n="10"
                         />syodaryānalapariṇāmena kṣīrasaṃtānivat avayavastenātatān śleṣmaṇāveṣṭitān
                         dhātusaṃdhitvāt ||<pb n="46"/>kalābhāgasya saṃdhiṣu śleṣmā atas tenāveṣṭitān
                         | </l>
 
                     <l xml:id="NC.3.4.8">
-                        <label>NC.3.4.8</label> āsāṃ prathamā māṃsadharā | yayāghriyate
-                        māṃsaśirādayā | </l>
+                        <label>NC.3.4.8</label>
+                         āsāṃ prathamā māṃsadharā | yayāghriyate māṃsaśirādayā | </l>
 
                     <l xml:id="NC.3.4.9"/>
 
                     <l xml:id="NC.3.4.10">
-                        <label>NC.3.4.10</label> dvi<lb n="2"/>tīyā raktadharā | māṃsābhyaṃtaragatā
-                        | asyāṃ śoṇitaṃ māsābhyaṃtara sāmānyena tiṣṭhati viśeṣataḥ | punaḥ śirāsu
-                            |<lb n="3"/>yakṛtplīho ceti | </l>
+                        <label>NC.3.4.10</label>
+                         dvi<lb n="2"/>tīyā raktadharā | māṃsābhyaṃtaragatā | asyāṃ śoṇitaṃ
+                        māsābhyaṃtara sāmānyena tiṣṭhati viśeṣataḥ | punaḥ śirāsu |<lb n="3"
+                        />yakṛtplīho ceti | </l>
 
                     <l xml:id="NC.3.4.11"/>
 
                     <l xml:id="NC.3.4.12-13">
-                        <label>NC.3.4.12-13</label> tṛtīyā medodharā nāma | athetareṣu sarvveṣu
-                        saraktaṃ meda ucyate | iti | māṃsān niḥsṛtatvān me<lb n="4"/>dasaḥ raktatā |
-                        anye tu sneho medaścitāścita evaṃti | etena tṛtīyakalāyāṃ
-                        medomajjānoghriyata | iti prati<lb n="5"/> pāditaṃ | etena sthānaikatvena
-                        majñaḥ pṛthak kalā nāsti | na cāpi medasaḥ pṛthak snehatā |
-                        paṃcasnehatvaprasaṃgāt |<lb n="6"/>vasānupṛthag eva majñaḥ | tābhyāṃ tasyāḥ
-                        pṛthak avasthānāt | vasāyās tu asthnibhyo baṃdir eva sthānaṃ saivocyate |
-                            va<lb n="7"/>āsati medomajñoḥ punarasthivivarāvasthānena sthānaikyād
-                        ekasnehakalpanaṃ | <unclear>ye</unclear>hi snehaṃ majñatrayā dadato te<lb
-                            n="8"/>hyasthāny eva pū<unclear>rṇṇā</unclear>ni tiktāthya snehaṃ
-                        gṛhnaṃti | na ca tatrāśakyatvāt trayor bhedaṃ kalpayaṃti || vasāsaṃgrāhiṇas
-                        tu vasāyā<lb n="9"/>bahiḥ sthita medaso durvijayabhajatvā tathā māṃsād eva
-                        ubhayor api saṃbhavatven ekaguṇatvāt || sāmānyena udarādi<lb n="10"/>sthita
+                        <label>NC.3.4.12-13</label>
+                         tṛtīyā medodharā nāma | athetareṣu sarvveṣu saraktaṃ meda ucyate | iti |
+                        māṃsān niḥsṛtatvān me<lb n="4"/>dasaḥ raktatā | anye tu sneho medaścitāścita
+                        evaṃti | etena tṛtīyakalāyāṃ medomajjānoghriyata | iti prati<lb n="5"/>
+                        pāditaṃ | etena sthānaikatvena majñaḥ pṛthak kalā nāsti | na cāpi medasaḥ
+                        pṛthak snehatā | paṃcasnehatvaprasaṃgāt |<lb n="6"/>vasānupṛthag eva majñaḥ
+                        | tābhyāṃ tasyāḥ pṛthak avasthānāt | vasāyās tu asthnibhyo baṃdir eva
+                        sthānaṃ saivocyate | va<lb n="7"/>āsati medomajñoḥ
+                        punarasthivivarāvasthānena sthānaikyād ekasnehakalpanaṃ |
+                            <unclear>ye</unclear>hi snehaṃ majñatrayā dadato te<lb n="8"/>hyasthāny
+                        eva pū<unclear>rṇṇā</unclear>ni tiktāthya snehaṃ gṛhnaṃti | na ca
+                        tatrāśakyatvāt trayor bhedaṃ kalpayaṃti || vasāsaṃgrāhiṇas tu vasāyā<lb
+                            n="9"/>bahiḥ sthita medaso durvijayabhajatvā tathā māṃsād eva ubhayor
+                        api saṃbhavatven ekaguṇatvāt || sāmānyena udarādi<lb n="10"/>sthita
                         māsamedasor ubhayor api kvāthasnehaṃ vasām āhuḥ | ata eva atra kecid evaṃ
                         paṭhaṃti || śuddhamāṃsasya yaḥ snehaḥ<pb n="47"/>sā vasā parikīrttitā ||
                         tathetareṣu sarveṣu sneho medo vibhāvita iti || itareṣv iti | aśuddheṣu
@@ -228,8 +234,9 @@
                             n="3"/> medasnehe pragṛhyate || </l>
 
                     <l xml:id="NC.3.4.14-17">
-                        <label>NC.3.4.14-17</label> caturthī śleṣmadharā nāma aṃtaḥkoṣṭhe ity ādi |
-                        tatrāpy asyāḥ purīṣa<unclear>vadhāpya</unclear>sti | tatraiva<lb n="4"/> hi
+                        <label>NC.3.4.14-17</label>
+                         caturthī śleṣmadharā nāma aṃtaḥkoṣṭhe ity ādi | tatrāpy asyāḥ
+                            purīṣa<unclear>vadhāpya</unclear>sti | tatraiva<lb n="4"/> hi
                         ravirbhāgaiḥ puṃktidṛśya purīṣatvāt sopy atra purīṣavibhāgo agnimārutakṛtaḥ
                         | tatrāgnikṛto vivecaya<lb n="5"/>ti | ca rasadoṣamūtrapurīṣāṇīti vacanāt |
                         koṣṭho vibhajati | tat koṣṭhāt pṛthak karoti | etāvān eva hi |<lb n="6"
@@ -250,140 +257,143 @@
                         purīṣadhareti | viśeṣaṇam asyāḥ | </l>
 
                     <l xml:id="NC.3.4.18">
-                        <label>NC.3.4.18</label> ṣaṣṭhī pittadharā nāma | <lb n="4"/>yā caturvidhaṃ
-                        catuḥprakāraṃ aśitādi bhedena āśayāt kaphāśayāt pracyutaṃ bhraṣṭaṃ
-                        pakvāśayopasthitaṃ pacyamā<lb n="5"/> nāśayagataṃ || āmapakvāśayayor api
-                        sthānasyānyataravyapadeśaḥ | tathā hi carakaḥ || atrāmāśayo viśeṣeṇa<lb
-                            n="6"/>pittasthānaṃ tasyaiva pakvāśayaṃ vyapadeśo pi pakvāśayagate doṣe
-                        virekārthaṃ prayojayet || tatropasthitaṃ<del>ḥ</del><lb n="7"/>prāptam
-                        āgatam annaṃ dhārayatīti | abhitaḥ sāmarthyataḥ ūrdhvam āmāśayepy adhaś ca
-                        pakvāśayepi pacati | param ayaṃ viśe<lb n="8"/>ṣaḥ | agner ūrdhvagatitvāt
-                        jvālāsadṛśair ūṣmabhiḥ kaphāśaye<unclear>kramrsa</unclear>madhyam avapākaṃ
-                        karoti | pittāśaye tu pi<lb n="9"/>ttoṣmalakṣyāṇā vahniḥ atyusannam annaṃ
-                        vidhūmāṃgārajātam ivāṃśaśaktaṃ pacanīyaṃ || bhṛśaṃ pacati || pakvāśayo<lb
-                            n="10"/> punar adhobhāgagataṃ kidṛm ūrdhvastho vahniḥ vaharagnir ivādhaḥ
-                        samīpasthaṃ pācyaṃ kiṃcid eva pacatiḥ | tam eva tāpaśo<pb n="49"/>ṣalakṣaṇaṃ
-                        pākam anilopy upavṛṃhayati | tasyāpi śoṣakaratvāt | ata eva carakepy uktaṃ
-                        || śoṣyamāṇasya vahni<lb n="2"/>neti || ata eva hetor atrāpi śloke
-                        anilānilāśayaprāpakaṃ koṣṭhagrahaṇaṃ || śoṣitam iti viśeṣaṇaṃ prāye <lb
-                            n="3"/>ṇa vātāśaye vātenaiva | āmapakvāśayayor hi viklitilakṣaṇasyaiva
-                        pākasya vidyamānatvāt || tad uktaṃ || samupa<lb n="4"/>klinnadhātva<add
-                            place="left-margin">nna</add>m iti || āmāśayapākaprapāka iti | praśabdaḥ
-                        ādikarmmadyotanārtha kṛ<unclear>to</unclear> pittāśaye tu || pacyamānasyeti
-                        | pakvā<lb n="5"/>śaye śoṣyamāṇasyetyarthaḥ || bhoje 'pi | āmāśayacyutaṃ hy
-                        annaṃ pakvāśayam upasthitāṃ tatrāpi pākaṃ prāpnoti mārutoṣmopa<lb n="6"/>
-                        pāditaṃ || </l>
+                        <label>NC.3.4.18</label>
+                         ṣaṣṭhī pittadharā nāma | <lb n="4"/>yā caturvidhaṃ catuḥprakāraṃ aśitādi
+                        bhedena āśayāt kaphāśayāt pracyutaṃ bhraṣṭaṃ pakvāśayopasthitaṃ pacyamā<lb
+                            n="5"/> nāśayagataṃ || āmapakvāśayayor api sthānasyānyataravyapadeśaḥ |
+                        tathā hi carakaḥ || atrāmāśayo viśeṣeṇa<lb n="6"/>pittasthānaṃ tasyaiva
+                        pakvāśayaṃ vyapadeśo pi pakvāśayagate doṣe virekārthaṃ prayojayet ||
+                            tatropasthitaṃ<del>ḥ</del><lb n="7"/>prāptam āgatam annaṃ dhārayatīti |
+                        abhitaḥ sāmarthyataḥ ūrdhvam āmāśayepy adhaś ca pakvāśayepi pacati | param
+                        ayaṃ viśe<lb n="8"/>ṣaḥ | agner ūrdhvagatitvāt jvālāsadṛśair ūṣmabhiḥ
+                            kaphāśaye<unclear>kramrsa</unclear>madhyam avapākaṃ karoti | pittāśaye
+                        tu pi<lb n="9"/>ttoṣmalakṣyāṇā vahniḥ atyusannam annaṃ vidhūmāṃgārajātam
+                        ivāṃśaśaktaṃ pacanīyaṃ || bhṛśaṃ pacati || pakvāśayo<lb n="10"/> punar
+                        adhobhāgagataṃ kidṛm ūrdhvastho vahniḥ vaharagnir ivādhaḥ samīpasthaṃ pācyaṃ
+                        kiṃcid eva pacatiḥ | tam eva tāpaśo<pb n="49"/>ṣalakṣaṇaṃ pākam anilopy
+                        upavṛṃhayati | tasyāpi śoṣakaratvāt | ata eva carakepy uktaṃ || śoṣyamāṇasya
+                            vahni<lb n="2"/>neti || ata eva hetor atrāpi śloke anilānilāśayaprāpakaṃ
+                        koṣṭhagrahaṇaṃ || śoṣitam iti viśeṣaṇaṃ prāye <lb n="3"/>ṇa vātāśaye
+                        vātenaiva | āmapakvāśayayor hi viklitilakṣaṇasyaiva pākasya vidyamānatvāt ||
+                        tad uktaṃ || samupa<lb n="4"/>klinnadhātva<add place="left-margin"
+                        >nna</add>m iti || āmāśayapākaprapāka iti | praśabdaḥ ādikarmmadyotanārtha
+                            kṛ<unclear>to</unclear> pittāśaye tu || pacyamānasyeti | pakvā<lb n="5"
+                        />śaye śoṣyamāṇasyetyarthaḥ || bhoje 'pi | āmāśayacyutaṃ hy annaṃ pakvāśayam
+                        upasthitāṃ tatrāpi pākaṃ prāpnoti mārutoṣmopa<lb n="6"/> pāditaṃ || </l>
 
                     <l xml:id="NC.3.4.19">
-                        <label>NC.3.4.19</label> etam evārthaṃ ślokena darśayannāha || aśitaṃ |
-                        khāditam ity ādi || yathākālaṃ kālān atikrameṇa
-                            <unclear>dā</unclear>tīkṣṇamadhya<lb n="7"/> maṃdāgniṣu
-                        māśadravyagurulaghuṣūcitakālānukrameṇa kālas tu varṣādikam
+                        <label>NC.3.4.19</label>
+                         etam evārthaṃ ślokena darśayannāha || aśitaṃ | khāditam ity ādi ||
+                        yathākālaṃ kālān atikrameṇa <unclear>dā</unclear>tīkṣṇamadhya<lb n="7"/>
+                        maṃdāgniṣu māśadravyagurulaghuṣūcitakālānukrameṇa kālas tu varṣādikam
                         abhinirvvarttayatīti carakavacanāt ||</l>
 
                     <l xml:id="NC.3.4.20-21">
-                        <label>NC.3.4.20-21</label> sapta<lb n="8"/>mī śukradharānāma śukrasya
-                        sarvāṃgavyāpitve upamānaṃ pramāṇaṃ darśayan āha || yathā payasītyādi ||
-                        dṛṣṭāṃtadvayam atrṛcaṃ mṛ<lb n="9"/>duvegapuruṣagatavyāpārasya
-                        alpabāhulyasyasūcanaparaṃ ||</l>
+                        <label>NC.3.4.20-21</label>
+                         sapta<lb n="8"/>mī śukradharānāma śukrasya sarvāṃgavyāpitve upamānaṃ
+                        pramāṇaṃ darśayan āha || yathā payasītyādi || dṛṣṭāṃtadvayam atrṛcaṃ mṛ<lb
+                            n="9"/>duvegapuruṣagatavyāpārasya alpabāhulyasyasūcanaparaṃ ||</l>
 
                     <l xml:id="NC.3.4.22-23">
-                        <label>NC.3.4.22-23</label> tasyaidānīṃ sarvāṃgavyāpinā'pi harṣādibhiḥ
-                            viśiṣṭa<lb n="10"/>dehasamutthitasthāpita prakarṣavarttanaṃ darśayan āha
-                        || dvyaṃgula ity ādi | vāme tārapārśvadeśe mūtraśrotraṃ smṛtaṃ gataṃ |
-                            pra<pb n="50"/>karṣeṇa pravarttate | sarvāṃgeṣu punar apakarṣaṃ ca |
-                        vadaṃti | mūtraśrotrasyeva śukrapravṛttadvāreṇa ārttavam api strīṇāṃ<lb
-                            n="2"/>pravarttate | </l>
+                        <label>NC.3.4.22-23</label>
+                         tasyaidānīṃ sarvāṃgavyāpinā'pi harṣādibhiḥ viśiṣṭa<lb n="10"
+                        />dehasamutthitasthāpita prakarṣavarttanaṃ darśayan āha || dvyaṃgula ity ādi
+                        | vāme tārapārśvadeśe mūtraśrotraṃ smṛtaṃ gataṃ | pra<pb n="50"/>karṣeṇa
+                        pravarttate | sarvāṃgeṣu punar apakarṣaṃ ca | vadaṃti | mūtraśrotrasyeva
+                        śukrapravṛttadvāreṇa ārttavam api strīṇāṃ<lb n="2"/>pravarttate | </l>
 
                     <l xml:id="NC.3.4.24">
-                        <label>NC.3.4.24</label> tasya ca sarvadaiva vidyamānatvepi yena hetunā
-                        garbhiṇyā ārttavaṃ na dṛśyate | taṃ darśayan āha || gṛhītaga<lb n="3"
-                        />rbhāṇām ity ādi || adhaḥ pratihatam ity ādi || pravahacchalilam iva
-                        nāḍīnirodhenupacīyate copari | uparyupaca<lb n="4"/>yenā'paceti nirucyate |
-                        yoṣitaś ca enām amalām ity āhuḥ | śāstrarājarāyasaṃjñaṃ mūḍhagarbhakarmmaṇi
-                        | yadāha |<lb n="5"/>carakaḥ | jarāyu ca dehoparigataṃ
-                        garbhaśarīrāvaguṃṭhakaṃ kṣīrasaṃtānikā sadṛśaṃ | tathāmālākhyaṃ cobhayam
-                            evai<lb n="6"/>tat | ārttavajaṃ rasavahanāḍī ca garbhānābhināḍīsaṃbaddhā
-                        || tad uktaṃ bhoje || raktā jarāyur bhavati nāḍī caiva rasā<lb n="7"/>tmikā
-                        | sā nāḍī garbham āpnoti tayā garbhasya varttanaṃ || śeṣam aṃkasthānāpacitād
-                        anyāt nāḍīmukhaiḥ prattyāvṛtyā<lb n="8"/>āvṛttaṃ cordhvatam aāgataṃ
-                        payodharau ષ<add place="bottom-margin"> abhi</add>pratidahyate |
-                        payodharāyoṛ śukravahaśrotomūlatvāt śukravahārttavavaha<lb n="9"/>yoś ca
-                        śrotasor abhedāt | ārttavasya raktatvāt | garbhasya raktajāni koṣṭhāṃgāni
-                        kānicad iti nirddiśan āha || </l>
+                        <label>NC.3.4.24</label>
+                         tasya ca sarvadaiva vidyamānatvepi yena hetunā garbhiṇyā ārttavaṃ na
+                        dṛśyate | taṃ darśayan āha || gṛhītaga<lb n="3"/>rbhāṇām ity ādi || adhaḥ
+                        pratihatam ity ādi || pravahacchalilam iva nāḍīnirodhenupacīyate copari |
+                            uparyupaca<lb n="4"/>yenā'paceti nirucyate | yoṣitaś ca enām amalām ity
+                        āhuḥ | śāstrarājarāyasaṃjñaṃ mūḍhagarbhakarmmaṇi | yadāha |<lb n="5"
+                        />carakaḥ | jarāyu ca dehoparigataṃ garbhaśarīrāvaguṃṭhakaṃ kṣīrasaṃtānikā
+                        sadṛśaṃ | tathāmālākhyaṃ cobhayam evai<lb n="6"/>tat | ārttavajaṃ
+                        rasavahanāḍī ca garbhānābhināḍīsaṃbaddhā || tad uktaṃ bhoje || raktā jarāyur
+                        bhavati nāḍī caiva rasā<lb n="7"/>tmikā | sā nāḍī garbham āpnoti tayā
+                        garbhasya varttanaṃ || śeṣam aṃkasthānāpacitād anyāt nāḍīmukhaiḥ
+                            prattyāvṛtyā<lb n="8"/>āvṛttaṃ cordhvatam aāgataṃ payodharau ષ<add
+                            place="bottom-margin"> abhi</add>pratidahyate | payodharāyoṛ
+                        śukravahaśrotomūlatvāt śukravahārttavavaha<lb n="9"/>yoś ca śrotasor abhedāt
+                        | ārttavasya raktatvāt | garbhasya raktajāni koṣṭhāṃgāni kānicad iti
+                        nirddiśan āha || </l>
 
                     <l xml:id="NC.3.4.25">
-                        <label>NC.3.4.25</label> ga<lb n="10"/>rbhasya khalvity ādi || śoṇitasya ca
-                        yatphenabhūtau avayava<unclear>sṛjñā</unclear> -hṛdayasya vāmapārśvavarttī
-                        phupphusaḥ phupphuṃḍa<pb n="51"/>iti prasiddhā | śoṇita malaja ity ādi ||
+                        <label>NC.3.4.25</label>
+                         ga<lb n="10"/>rbhasya khalvity ādi || śoṇitasya ca yatphenabhūtau
+                            avayava<unclear>sṛjñā</unclear> -hṛdayasya vāmapārśvavarttī phupphusaḥ
+                            phupphuṃḍa<pb n="51"/>iti prasiddhā | śoṇita malaja ity ādi ||
                         ikṣurasapākamalavat yaḥ śoṇitamalas tajjā uṃdukaḥ |
                             pradoṣṭo<unclear>'nnu</unclear>pra<lb n="2"/>deśaḥ | purīṣādhānaṃ
                         uṃṇḍakaḥ | </l>
 
                     <l xml:id="NC.3.4.26-30">
-                        <label>NC.3.4.26-30</label> kṣudrāṃtragudavastisaṃbhavaṃ darśayan āha ||
-                        asṛjaśleṣmaś cāpītyādi | kṣudrāṃtraguda<lb n="3"/>vastiślokābhone 'pi |
-                        bhṛśā eva jihvāsaṃbhavaṃ darśayan āha || atrāsyetyādi || garbhasya
-                        sarvapacyamānasya vāyu<lb n="4"/>nā tatreti tatreti hṛdaye prāṇāpānābhyāṃ
-                        muhurmuhur eva praśa<unclear>u</unclear>ttiṣṭhadbhyāṃ hṛdayasyeva ādhmānāt |
-                        parataṃtra pratyayācca<lb n="5"/> tad uktaṃ hiraṇyākhyor ukmabaddhasya
-                        mānasya garbhasya hṛdi vāyunā | kapharaktaprasādena syāj
-                            jihvākapharaktaje<lb n="6"/>ti || pūrvoktadehadūṣyānuvṛtter anyānukteś
-                        ca | pūrvoktaparataṃtrobhayor eva uktatvāt | anye tu pa|ṭhaṃti | hṛdaye
-                            pa<lb n="7"/>cyamānānāṃ mādhmā<unclear>padrukma</unclear>sākhāt |
-                        kaphaśoṇitamāsānāṃ sārājihvā prajāyate || atrāpi hṛdyādhmānāt pacyamānā<lb
-                            n="8"/>nāṃ kaphādīnām iti saṃbaṃdhaḥ | kecid atra
-                        koṣṭhāṃgajihvāprasaṃgena nāśāśrota|peśīśarādyāśaya vṛkkavṛṣaṇānāṃ he<lb
-                            n="9"/>tum utpattiṃ ca paṭhaṃti || tannātiprasiddhaṃ || </l>
+                        <label>NC.3.4.26-30</label>
+                         kṣudrāṃtragudavastisaṃbhavaṃ darśayan āha || asṛjaśleṣmaś cāpītyādi |
+                            kṣudrāṃtraguda<lb n="3"/>vastiślokābhone 'pi | bhṛśā eva jihvāsaṃbhavaṃ
+                        darśayan āha || atrāsyetyādi || garbhasya sarvapacyamānasya vāyu<lb n="4"
+                        />nā tatreti tatreti hṛdaye prāṇāpānābhyāṃ muhurmuhur eva
+                            praśa<unclear>u</unclear>ttiṣṭhadbhyāṃ hṛdayasyeva ādhmānāt | parataṃtra
+                            pratyayācca<lb n="5"/> tad uktaṃ hiraṇyākhyor ukmabaddhasya mānasya
+                        garbhasya hṛdi vāyunā | kapharaktaprasādena syāj jihvākapharaktaje<lb n="6"
+                        />ti || pūrvoktadehadūṣyānuvṛtter anyānukteś ca | pūrvoktaparataṃtrobhayor
+                        eva uktatvāt | anye tu pa|ṭhaṃti | hṛdaye pa<lb n="7"/>cyamānānāṃ
+                            mādhmā<unclear>padrukma</unclear>sākhāt | kaphaśoṇitamāsānāṃ sārājihvā
+                        prajāyate || atrāpi hṛdyādhmānāt pacyamānā<lb n="8"/>nāṃ kaphādīnām iti
+                        saṃbaṃdhaḥ | kecid atra koṣṭhāṃgajihvāprasaṃgena nāśāśrota|peśīśarādyāśaya
+                        vṛkkavṛṣaṇānāṃ he<lb n="9"/>tum utpattiṃ ca paṭhaṃti || tannātiprasiddhaṃ || </l>
 
                     <l xml:id="NC.3.4.31-32">
-                        <label>NC.3.4.31-32</label> śoṇitakaphaprasādajaṃ hṛdayaṃ || tasya
-                        hṛdayasyā'dho vā majjātaḥ plīhā pupphu<lb n="10"/> saś ca dakṣiṇato
-                        yakṛtkloma ca || klomaḥ varṣabhūmiḥ | tadviśeṣeṇa cetanāsthānaṃ |
-                        caitanyāspadaṃ || sāmānyena saka<pb n="52"/>lam eva śarīraṃ cetanāsthānaṃ ||
-                        tad uktaṃ carake || vedanānām adhiṣṭhānaṃ manodehaś ca seṃdriyaḥ |
-                            keśalomanakhāgrāṃ<lb n="2"/>taṃ maladravaguṇair vinā iti || cetanādhātu
-                        sahacaritaṃ mānā'pi rajastamo doṣaṃ hṛdi viśeṣeṇa tat punaruṇatvā<lb n="3"
-                        />t | āśugamity anenaiva saphalaśarīragatam api mano viśeṣeṇa hṛdayagataṃ |
-                        uktaṃ hi prāk || tadāśrayāśrayā hi dha<lb n="4"/>manyaḥ prāṇavahāḥ prāṇeṣv
-                        iṃdrayamanorajastamasāṃ pāṭhāt || tamasā hṛdayāvaraṇe citteṃdriyavaha
-                        dhamanīti rodhāt || <lb n="5"/>tamo mohena cakṣurādi grāhyarūpādīnāṃ
-                        pratijñābhāvaḥ | tathaivāṃtarmmano vahaśrotasāṃ ca tamovaraṇāt manasaḥ<lb
-                            n="6"/>sukhaduḥkhādi jñānābhāvaś ca | yathātra suptasya svapnajñānaṃ
-                        tathottaratra vakṣyatīti || tad uktaṃ carake || yadā tu manasaḥ<lb n="7"
-                        />klāṃte karmmātmanaḥ klamānvitāḥ | viṣayebhyo nivarttaṃte tadā svapiti
-                        mānavaḥ | cittādikaraṇānāṃ viśeṣamayo<lb n="8"/>gaṃ ca karmmapuruṣacaitanyaṃ
-                        anuvarttate iti || anekaśo vyākhyātaṃ tad uktaṃ carake | ātmanaḥ karaṇair
-                        yāgāt ||<lb n="9"/>jñānaṃ tasya pravarttate | karaṇānāṃ ca vaimalyād ayogād
-                        vā na varttate || iti || idānīṃ niśānidrāyāḥ bhāvahetuṃ<lb n="10"/>darśayan
-                        āha || asmiṃs tu tamasāvṛte ity ādi || anāvṛte punaḥ pravarttaṃte tasyaiva
-                        hṛdayasyākāraṃ da<del>''</del> rśayan āha ||<pb n="53"/>puṃḍarīkasamam ity
-                        ādi || jāgrato vikaśaty ahni svapne naktaṃ ca mīlati | svabhāvakṛtamasya
-                        naktaṃ svapne mīlanaṃ | viparya<lb n="2"/>ye prabodha iti |</l>
+                        <label>NC.3.4.31-32</label>
+                         śoṇitakaphaprasādajaṃ hṛdayaṃ || tasya hṛdayasyā'dho vā majjātaḥ plīhā
+                            pupphu<lb n="10"/> saś ca dakṣiṇato yakṛtkloma ca || klomaḥ varṣabhūmiḥ
+                        | tadviśeṣeṇa cetanāsthānaṃ | caitanyāspadaṃ || sāmānyena saka<pb n="52"
+                        />lam eva śarīraṃ cetanāsthānaṃ || tad uktaṃ carake || vedanānām adhiṣṭhānaṃ
+                        manodehaś ca seṃdriyaḥ | keśalomanakhāgrāṃ<lb n="2"/>taṃ maladravaguṇair
+                        vinā iti || cetanādhātu sahacaritaṃ mānā'pi rajastamo doṣaṃ hṛdi viśeṣeṇa
+                        tat punaruṇatvā<lb n="3"/>t | āśugamity anenaiva saphalaśarīragatam api mano
+                        viśeṣeṇa hṛdayagataṃ | uktaṃ hi prāk || tadāśrayāśrayā hi dha<lb n="4"
+                        />manyaḥ prāṇavahāḥ prāṇeṣv iṃdrayamanorajastamasāṃ pāṭhāt || tamasā
+                        hṛdayāvaraṇe citteṃdriyavaha dhamanīti rodhāt || <lb n="5"/>tamo mohena
+                        cakṣurādi grāhyarūpādīnāṃ pratijñābhāvaḥ | tathaivāṃtarmmano vahaśrotasāṃ ca
+                        tamovaraṇāt manasaḥ<lb n="6"/>sukhaduḥkhādi jñānābhāvaś ca | yathātra
+                        suptasya svapnajñānaṃ tathottaratra vakṣyatīti || tad uktaṃ carake || yadā
+                        tu manasaḥ<lb n="7"/>klāṃte karmmātmanaḥ klamānvitāḥ | viṣayebhyo
+                        nivarttaṃte tadā svapiti mānavaḥ | cittādikaraṇānāṃ viśeṣamayo<lb n="8"/>gaṃ
+                        ca karmmapuruṣacaitanyaṃ anuvarttate iti || anekaśo vyākhyātaṃ tad uktaṃ
+                        carake | ātmanaḥ karaṇair yāgāt ||<lb n="9"/>jñānaṃ tasya pravarttate |
+                        karaṇānāṃ ca vaimalyād ayogād vā na varttate || iti || idānīṃ niśānidrāyāḥ
+                            bhāvahetuṃ<lb n="10"/>darśayan āha || asmiṃs tu tamasāvṛte ity ādi ||
+                        anāvṛte punaḥ pravarttaṃte tasyaiva hṛdayasyākāraṃ da<del>''</del> rśayan
+                        āha ||<pb n="53"/>puṃḍarīkasamam ity ādi || jāgrato vikaśaty ahni svapne
+                        naktaṃ ca mīlati | svabhāvakṛtamasya naktaṃ svapne mīlanaṃ | viparya<lb
+                            n="2"/>ye prabodha iti |</l>
 
                     <l xml:id="NC.3.4.33">
-                        <label>NC.3.4.33</label> prākṛtā me nidrāṃ darśayan āha || nidrāṃ tu
-                        vaiṣṇavīm ity ādi | viṣṇor iyaṃ vaiṣṇavī yā sā loke nāmavi<lb n="3"/>śeṣeṇās
-                        te pāpmeti | sā hi cetaso vivekaṃ prabodhaṃ nirasya svāpakṛtam iva prabodhaṃ
-                        dadhātīti | sā iyaṃ janmapra<lb n="4"/>bhṛti spṛśaṃtī janmabhūtāpi
-                        yāvajjīvam evās te | tenaivam aviṣayacikitsitasya prakṛtibhūtatvāt
-                            janmakā<lb n="5"/>lajā nidrām abhidhāya maraṇakālajāṃ nidrāṃ prākṛtām
-                        eva nirddiśan āha || tatra yadetyādi || anabodhinītija<lb n="6"/>jaḍaḥ |
-                        avabodho 'navabodhaḥ | sa yasyāstīti nity ayoge matvarthīyaḥ | saṃjñāvahāni
-                        cetanādhātukṛt samyak<lb n="7"/> jātavahāni badhnāni prāṇādi vahāni sakalāni
-                        śrotāṃsi | kaphaḥ prabalatamaś ca tatas tena prabalatamaskṛte<lb n="8"
-                        />cetanā śrotāni vahanirodhāt | punaraprabodhinī sānijā etās tisraḥ |
-                        tatrāsāṃ sāmānya saṃprāpti vātha mana<lb n="9"/>saḥ śarīradoṣasya hīti
-                        prācīna ekā niśā nidrā | tathāpare maraṇajanmakālabhaved veprakṛtyau
-                        svabhāvabhūtatvā| <lb n="10"/>d āsām iti | niśā janmamaraṇakālabhāvena tisro
-                        nirddiśya manasoha rūpatvāt nidrāyāḥ pratyāsatyāsanneḥ pūrvaṃ<pb n="54"
-                        />manodoṣaprakṛtividroṣaṃ nirddiśan āha || tatra tamoyaṣṭīnām ity ādi..nā
-                        manasā mano doṣeṇa hi hṛdayaśa<lb n="2"/>kalasyava klamevamālanaṃ || tataḥ
-                        svāpas tatraiva tamo bhūyiṣṭhānāṃ punaraha svapīti bhūyo nidrāvidhiḥ |
-                            rajobhūyiṣṭhā<lb n="3"/>nām animittaṃ | rajaś calatvena kadācid ahaḥsu
-                        niśāsu vā bhavati | na bhavati | ceti madhyanidrāvadhiḥ | satvabhūyiṣṭhānām
-                        a <lb n="4"/>rddharātro pūrvasmin veti |
-                        kṣīṇatamasa<unclear>stvā</unclear>ddoṣālpatā ity arthaḥ | na punar
+                        <label>NC.3.4.33</label>
+                         prākṛtā me nidrāṃ darśayan āha || nidrāṃ tu vaiṣṇavīm ity ādi | viṣṇor iyaṃ
+                        vaiṣṇavī yā sā loke nāmavi<lb n="3"/>śeṣeṇās te pāpmeti | sā hi cetaso
+                        vivekaṃ prabodhaṃ nirasya svāpakṛtam iva prabodhaṃ dadhātīti | sā iyaṃ
+                            janmapra<lb n="4"/>bhṛti spṛśaṃtī janmabhūtāpi yāvajjīvam evās te |
+                        tenaivam aviṣayacikitsitasya prakṛtibhūtatvāt janmakā<lb n="5"/>lajā nidrām
+                        abhidhāya maraṇakālajāṃ nidrāṃ prākṛtām eva nirddiśan āha || tatra yadetyādi
+                        || anabodhinītija<lb n="6"/>jaḍaḥ | avabodho 'navabodhaḥ | sa yasyāstīti
+                        nity ayoge matvarthīyaḥ | saṃjñāvahāni cetanādhātukṛt samyak<lb n="7"/>
+                        jātavahāni badhnāni prāṇādi vahāni sakalāni śrotāṃsi | kaphaḥ prabalatamaś
+                        ca tatas tena prabalatamaskṛte<lb n="8"/>cetanā śrotāni vahanirodhāt |
+                        punaraprabodhinī sānijā etās tisraḥ | tatrāsāṃ sāmānya saṃprāpti vātha
+                            mana<lb n="9"/>saḥ śarīradoṣasya hīti prācīna ekā niśā nidrā | tathāpare
+                        maraṇajanmakālabhaved veprakṛtyau svabhāvabhūtatvā| <lb n="10"/>d āsām iti |
+                        niśā janmamaraṇakālabhāvena tisro nirddiśya manasoha rūpatvāt nidrāyāḥ
+                        pratyāsatyāsanneḥ pūrvaṃ<pb n="54"/>manodoṣaprakṛtividroṣaṃ nirddiśan āha ||
+                        tatra tamoyaṣṭīnām ity ādi..nā manasā mano doṣeṇa hi hṛdayaśa<lb n="2"
+                        />kalasyava klamevamālanaṃ || tataḥ svāpas tatraiva tamo bhūyiṣṭhānāṃ
+                        punaraha svapīti bhūyo nidrāvidhiḥ | rajobhūyiṣṭhā<lb n="3"/>nām animittaṃ |
+                        rajaś calatvena kadācid ahaḥsu niśāsu vā bhavati | na bhavati | ceti
+                        madhyanidrāvadhiḥ | satvabhūyiṣṭhānām a <lb n="4"/>rddharātro pūrvasmin veti
+                        | kṣīṇatamasa<unclear>stvā</unclear>ddoṣālpatā ity arthaḥ | na punar
                         arddharātra eva | tatra pittasyoktadadyena satve <add place="right'margin"
                             >kadye</add>na satvo<lb n="5"/>drekena prabodhaḥ | tad evaṃ pūrvābhis
                         tisṛbhiḥ saha ṣaḍapy ete prākṛtasvabhāvabhūtāt apratīkārā vā yogābhyāsena
@@ -405,26 +415,28 @@
                         evopariṣṭāccikitsitaṃ ||</l>
 
                     <l xml:id="NC.3.4.34-35">
-                        <label>NC.3.4.34-35</label> e<lb n="5"/>vam evārthe ślokena dṛḍhayannāha ||
-                        hṛdayaṃ cetanāsthānam ity ādi | <unclear>dihenaṃ</unclear> karmmapuruṣaṃ
-                        śrameṇa tamaḥ saṃbhavādatri<lb n="6"/> vathamajāthavarudhyate | tatra
-                        bhāvahetuṃ darśayannāha || nidrāhetur ity ādi | nidrāmanodoṣalakṣaṇāyās
-                            tamo<lb n="7"/>hetuḥ tasyācarakatvāt | prabodhanasya punariṃdriyāṇāṃ
-                        rūpādi prakāśalakṣaṇasya hetuḥ satvaṃ tasya prakāśakatvā<lb n="8"/>t |
-                        svabhāvo hetu nidrā prabodhayor iti | -yaḥ | tasya svabhāvasyāhetutvāt |
-                        tamaḥ satvayor anidrāprabodhayoḥ sva<lb n="9"/> bhāvenaiva hetutvaṃ |</l>
+                        <label>NC.3.4.34-35</label>
+                         e<lb n="5"/>vam evārthe ślokena dṛḍhayannāha || hṛdayaṃ cetanāsthānam ity
+                        ādi | <unclear>dihenaṃ</unclear> karmmapuruṣaṃ śrameṇa tamaḥ
+                            saṃbhavādatri<lb n="6"/> vathamajāthavarudhyate | tatra bhāvahetuṃ
+                        darśayannāha || nidrāhetur ity ādi | nidrāmanodoṣalakṣaṇāyās tamo<lb n="7"
+                        />hetuḥ tasyācarakatvāt | prabodhanasya punariṃdriyāṇāṃ rūpādi
+                        prakāśalakṣaṇasya hetuḥ satvaṃ tasya prakāśakatvā<lb n="8"/>t | svabhāvo
+                        hetu nidrā prabodhayor iti | -yaḥ | tasya svabhāvasyāhetutvāt | tamaḥ
+                        satvayor anidrāprabodhayoḥ sva<lb n="9"/> bhāvenaiva hetutvaṃ |</l>
 
                     <l xml:id="NC.3.4.36">
-                        <label>NC.3.4.36</label> yataḥ na tu nidrātamo bhāvaivoktā tat kiṃ
-                        punaruktenā ucyate | bodhahetusatvaprasaṃgena atha<lb n="10"/>vā nidrāyāḥ
-                        svabhāvena tama evopavādakam ity etad artham anubodhyabhāvaḥ |
-                        svāpasvāpābhāvo bodhaḥ | tatkathaṃ sva<pb n="56"/>pnasya svapnāvabodho
-                        bhavatītyāha | pūrvadehānubhūtāṃ stvity ādi || <unclear>tū</unclear>gātmā
-                        bhūtair upalakṣitaḥ | karmmapuruṣaḥ sva<lb n="2"/>pataḥ svapnagato yadā
-                        viṣayān sukhaduḥkheti cittena śoṣyataḥ smṛtaḥ | kathaṃ punararthānidrayā
-                        grāhyāt gṛhṇā<lb n="3"/>tītyāha || manaseti manas tu sarvadevasaṃbhavāt |
-                        sadā svapnadarśanaprasaṃga ity āha || rajoyukteneti rajasā saha<lb n="4"
-                        />yogaṃ gatena rajasā pravarttate artheṣu manasaḥ pravarttitatvāt | tamasā
+                        <label>NC.3.4.36</label>
+                         yataḥ na tu nidrātamo bhāvaivoktā tat kiṃ punaruktenā ucyate |
+                        bodhahetusatvaprasaṃgena atha<lb n="10"/>vā nidrāyāḥ svabhāvena tama
+                        evopavādakam ity etad artham anubodhyabhāvaḥ | svāpasvāpābhāvo bodhaḥ |
+                        tatkathaṃ sva<pb n="56"/>pnasya svapnāvabodho bhavatītyāha |
+                        pūrvadehānubhūtāṃ stvity ādi || <unclear>tū</unclear>gātmā bhūtair
+                        upalakṣitaḥ | karmmapuruṣaḥ sva<lb n="2"/>pataḥ svapnagato yadā viṣayān
+                        sukhaduḥkheti cittena śoṣyataḥ smṛtaḥ | kathaṃ punararthānidrayā grāhyāt
+                            gṛhṇā<lb n="3"/>tītyāha || manaseti manas tu sarvadevasaṃbhavāt | sadā
+                        svapnadarśanaprasaṃga ity āha || rajoyukteneti rajasā saha<lb n="4"/>yogaṃ
+                        gatena rajasā pravarttate artheṣu manasaḥ pravarttitatvāt | tamasā
                         rūpamohasya yoge 'pi ajñānāt | na ta<lb n="5"/>moyuktena nāpi satvayuktena
                         manasaḥ satvayoge prabodhāt | mano hi purovartti sadvas tu gṛhṇāti | svapne
                             kimasa<lb n="6"/>dvas tu gṛhṇātītyāha || anubhūtānīti | dṛṣṭā
@@ -436,29 +448,32 @@
                         |</l>
 
                     <l xml:id="NC.3.4.37">
-                        <label>NC.3.4.37</label> nirvikāraḥ ka katham ātmāsvapatītyāha | karaṇānāṃ
-                        tu vaikalyādity ādi. kenākaraṇānāṃ vaika<lb n="10"/>lyādity ādi | tamaseti
-                        atisarvato bahiraṃtaś ca | tadvad iṃdriyāṇāṃ viṣayaṃ bhūterthe
-                        aṃtarmmanorthe 'pi sukhaduḥkhādau<pb n="57"/>asvapne ity upacāraḥ |
-                        karaṇadharmmānuvṛtte caitanyamātmanaḥ | tad uktaṃ carake | ātmājñeḥ karaṇaiḥ
-                        yogāt jñānaṃ tasya pravarttate || <caesura/> iṃ<lb n="2"/>driyāṇāṃ ca
-                        vaikalyāt ayogādvā na varttate |</l>
+                        <label>NC.3.4.37</label>
+                         nirvikāraḥ ka katham ātmāsvapatītyāha | karaṇānāṃ tu vaikalyādity ādi.
+                        kenākaraṇānāṃ vaika<lb n="10"/>lyādity ādi | tamaseti atisarvato bahiraṃtaś
+                        ca | tadvad iṃdriyāṇāṃ viṣayaṃ bhūterthe aṃtarmmanorthe 'pi
+                            sukhaduḥkhādau<pb n="57"/>asvapne ity upacāraḥ | karaṇadharmmānuvṛtte
+                        caitanyamātmanaḥ | tad uktaṃ carake | ātmājñeḥ karaṇaiḥ yogāt jñānaṃ tasya
+                        pravarttate ||
+                        <caesura/>
+                         iṃ<lb n="2"/>driyāṇāṃ ca vaikalyāt ayogādvā na varttate |</l>
 
                     <l xml:id="NC.3.4.38">
-                        <label>NC.3.4.38</label> tatra sthāpasthadivādi prāptasya niṣedhaṃ
-                        darśayannāha || sarvarttuṣu ity ādi | niṣi<lb n="3"/>ddhastuti | smṛtiṣu |
-                        tasya niṣiddhācaraṇe dṛṣṭāṃta dṛṣṭadoṣaṃ punaḥ paścād vakṣyati | tatra
-                            niṣiddhasyāpya<del>mra</del>sya kāle pātre ca <lb n="4"/>prāyaścittādiṣv
-                        anapratiṣedho bālādiṣu tatra bālasya sātmyatvāt | dṛṣṭena doṣaḥ | tatra
-                        adṛṣṭeḥ smṛtidṛṣṭe vā niṣe<lb n="5"/>dhāt | evaṃvidhādiṣv api
-                        dhātupṛṣṭibalakāraṇatvāt | dṛṣṭedṛṣṭepi vyādhitasya nity ākaraṇavadadoṣaḥ |
-                        tatra nity age kā<lb n="6"/>le grīṣme niṣedha | bālādiṣu punarāvasthikakāla
-                        iti yānādibhiḥ | sahasrāṃtaśabdaḥ pratyekam abhisaṃbadhyate | eṣā<lb n="7"/>
-                        matha bhuktavatāṃ tathā medaprabhṛtibhiḥ kṣīṇānāṃ tatra mārutena kṣīṇo
-                        mārutavṛddhikarśitaḥ | ajīrṇṇito divāsvā<lb n="8"/>pat | agnivṛddher
-                        avidāhor apānasya tataḥ pittakaphayor akopaḥ | muhṛtaṃ nālikādvayaṃ |
-                        jāgaraṇakālād arddham arddhā<lb n="9"/>gavāpratiṣedho 'dhikasu niṣiddha eva
-                        | dṛṣṭādṛṣṭadoṣakaratvāt | tatra kālenāpi svabhāvaḥ kiṃ syāktasyopādita<lb
+                        <label>NC.3.4.38</label>
+                         tatra sthāpasthadivādi prāptasya niṣedhaṃ darśayannāha || sarvarttuṣu ity
+                        ādi | niṣi<lb n="3"/>ddhastuti | smṛtiṣu | tasya niṣiddhācaraṇe dṛṣṭāṃta
+                        dṛṣṭadoṣaṃ punaḥ paścād vakṣyati | tatra niṣiddhasyāpya<del>mra</del>sya
+                        kāle pātre ca <lb n="4"/>prāyaścittādiṣv anapratiṣedho bālādiṣu tatra
+                        bālasya sātmyatvāt | dṛṣṭena doṣaḥ | tatra adṛṣṭeḥ smṛtidṛṣṭe vā niṣe<lb
+                            n="5"/>dhāt | evaṃvidhādiṣv api dhātupṛṣṭibalakāraṇatvāt | dṛṣṭedṛṣṭepi
+                        vyādhitasya nity ākaraṇavadadoṣaḥ | tatra nity age kā<lb n="6"/>le grīṣme
+                        niṣedha | bālādiṣu punarāvasthikakāla iti yānādibhiḥ | sahasrāṃtaśabdaḥ
+                        pratyekam abhisaṃbadhyate | eṣā<lb n="7"/> matha bhuktavatāṃ tathā
+                        medaprabhṛtibhiḥ kṣīṇānāṃ tatra mārutena kṣīṇo mārutavṛddhikarśitaḥ |
+                        ajīrṇṇito divāsvā<lb n="8"/>pat | agnivṛddher avidāhor apānasya tataḥ
+                        pittakaphayor akopaḥ | muhṛtaṃ nālikādvayaṃ | jāgaraṇakālād arddham
+                            arddhā<lb n="9"/>gavāpratiṣedho 'dhikasu niṣiddha eva |
+                        dṛṣṭādṛṣṭadoṣakaratvāt | tatra kālenāpi svabhāvaḥ kiṃ syāktasyopādita<lb
                             n="10"/>tvāt | ardram eva kālasvāpaḥ | kutaḥ kāraṇaṃ divā na svapyād iti
                         | divā hi svapnapradhāne prakāśakāle nidrāmoha<pb n="58"/>svabhāvā vikārāc
                         ceti dvā svapyāt | tatra svapatāṃ mānaśārīradoṣadvayaṃ nirddiśan āha ||
@@ -470,11 +485,12 @@
 
 
                     <l xml:id="NC.3.4.39-40">
-                        <label>NC.3.4.39-40</label> na jāgṛyād rātrau iti nidrāvidhiḥ | divāsvapnaṃ
-                        ca varjjayet ||<lb n="5"/>ditiniṣedham iti parimitaṃ nādhikaṃ na conam iti |
-                        anūnādhikaḥ svapnaphalaṃ darśayan āha | tathā hy arogaḥ sumanā<lb n="6"/>ity
-                        ādi | anūnādhikasvapnena avidyamānā vidyamānavātapittakapharogaḥ | sumanā
-                        iti || manovikārābhā<lb n="7"/>vaḥ || nātisthūlakṛśa iti samadehaḥ
+                        <label>NC.3.4.39-40</label>
+                         na jāgṛyād rātrau iti nidrāvidhiḥ | divāsvapnaṃ ca varjjayet ||<lb n="5"
+                        />ditiniṣedham iti parimitaṃ nādhikaṃ na conam iti | anūnādhikaḥ
+                        svapnaphalaṃ darśayan āha | tathā hy arogaḥ sumanā<lb n="6"/>ity ādi |
+                        anūnādhikasvapnena avidyamānā vidyamānavātapittakapharogaḥ | sumanā iti ||
+                            manovikārābhā<lb n="7"/>vaḥ || nātisthūlakṛśa iti samadehaḥ
                         samasvapnatvāt | śrīmān iti || varṇānvitatvāt || kāṃtimān
                             balavaṃśaktivyāyā<lb n="8"/> magamyād adhaḥ śuddhayo-tastvāt | tatra
                         sthūlasyāvṛtvaṃ | medasā śukravahaśroto 'varodhāt || atikṛśasya kṣīṇa|<lb
@@ -482,11 +498,12 @@
                         samāyurmānuṣapṛṣatyāḥ | </l>
 
                     <l xml:id="NC.3.4.41-46">
-                        <label>NC.3.4.41-46</label> tatra jāgaraṇasvāpayoḥ sātmībhūte|<lb n="10"/>pi
-                        adoṣaṃ darśayan āha || divā cetyādi || etena dṛṣṭasyālābhe manastāpe
-                        iṣṭalābhavidhānaṃ | aniṣṭālābhaje<pb n="59"/>punaraniṣṭāpanayaṃ | cikitsitam
-                        uktaṃ | evaṃ mahācārakramadoṣam api apekṣya yathā nidānaṃ pratyanīkam
-                        ācaraṇīyaṃ | <lb n="2"/>drākṣārasādīnāṃ naktam upāyogena kaphakṣayādijātāṃ
+                        <label>NC.3.4.41-46</label>
+                         tatra jāgaraṇasvāpayoḥ sātmībhūte|<lb n="10"/>pi adoṣaṃ darśayan āha ||
+                        divā cetyādi || etena dṛṣṭasyālābhe manastāpe iṣṭalābhavidhānaṃ |
+                            aniṣṭālābhaje<pb n="59"/>punaraniṣṭāpanayaṃ | cikitsitam uktaṃ | evaṃ
+                        mahācārakramadoṣam api apekṣya yathā nidānaṃ pratyanīkam ācaraṇīyaṃ | <lb
+                            n="2"/>drākṣārasādīnāṃ naktam upāyogena kaphakṣayādijātāṃ
                         kaphābhivṛddhiḥ |</l>
 
                     <l xml:id="NC.3.4.47"/>
@@ -508,62 +525,68 @@
                     <l xml:id="NC.3.4.55"/>
 
                     <l xml:id="NC.3.4.56">
-                        <label>NC.3.4.56</label> vihitasyāpi rātrisvāpasya kvacinniṣedhaṃ ||<lb
-                            n="3"/>tathā divāsvapnasyāpi niṣiddhasya kvacidvidhaṃ darśayan āha ||
-                        mūrchāpittetyādi | bhramaścakragatasyeva | uktāpi nidrāta<lb n="4"/>masā
-                        manodoṣeṇa mūrchādiprasaṃgena | śarīradoṣeṇāpi punarabhihiteti hetunā uktā
-                        yāstaṃdrāyāḥ staṃdrāyāsva<lb n="5"/>lakṣaṇaṃ nirddiśan āha || iṃdriyārtheṣv
+                        <label>NC.3.4.56</label>
+                         vihitasyāpi rātrisvāpasya kvacinniṣedhaṃ ||<lb n="3"/>tathā divāsvapnasyāpi
+                        niṣiddhasya kvacidvidhaṃ darśayan āha || mūrchāpittetyādi |
+                        bhramaścakragatasyeva | uktāpi nidrāta<lb n="4"/>masā manodoṣeṇa
+                        mūrchādiprasaṃgena | śarīradoṣeṇāpi punarabhihiteti hetunā uktā yāstaṃdrāyāḥ
+                            staṃdrāyāsva<lb n="5"/>lakṣaṇaṃ nirddiśan āha || iṃdriyārtheṣv
                         asaṃprāptir ity ādi | taṃdrālakṣaṇaprasaṃgena kecit klamālasyādīnām api
                             lakṣa<lb n="6"/>ṇaṃ paṭhaṃti | tanna teṣāṃ asūtritvāt |</l>
 
                     <l xml:id="NC.3.4.57">
-                        <label>NC.3.4.57</label> garbhasya vṛddho dvitīyam api hetuṃ nirddiśan āha |
-                        rasanimittā māturiti | viśeṣa|<lb n="7"/>garbhasyāśayādhmānanimittāt kathaṃ
+                        <label>NC.3.4.57</label>
+                         garbhasya vṛddho dvitīyam api hetuṃ nirddiśan āha | rasanimittā māturiti |
+                            viśeṣa|<lb n="7"/>garbhasyāśayādhmānanimittāt kathaṃ
                         vakṣyamāṇenānilānalakṛtena garbhaśrotasāṃdhmānenābhino
                             viśāla<unclear>bhūrtva</unclear>ta <lb n="8"/>tvāt |
                         mātrārasaparivarddhitamāsādyuchvāsaḥ | tad uktaṃ || ākāśaṃ vivarddhayati
                         |</l>
 
                     <l xml:id="NC.3.4.58-59">
-                        <label>NC.3.4.58-59</label> atra śrotasā nevādhmānasaṃprāptiṃ darśa<lb n="9"
-                        />yan āha || tasyāṃtareṇetyādi | tasya garbhasyanābher mmadhye agnisthānaṃ
-                        niścitaṃ | na trayotistho vāyurādhmāpayati | te<lb n="10"/>na dyotiḥ
-                        sthānādhmānena madhyaśroto vṛddho kathaṃ sarvato vṛddhir ity āha || kraṣmaṇo
-                        sahitaścetyādi | yathā yathā |<pb n="60"/>dārayati | arddham adhas tiryak
-                        tathā tathā varddhayati | yathā krameṇa dāraṇāt yathā krameṇa varddhanam ity
-                        arthaḥ || tad evam a<lb n="2"/>dhorddhvatiryag varddhanam ity arthaḥ | yadi
-                        sarvato varddhate |</l>
+                        <label>NC.3.4.58-59</label>
+                         atra śrotasā nevādhmānasaṃprāptiṃ darśa<lb n="9"/>yan āha ||
+                        tasyāṃtareṇetyādi | tasya garbhasyanābher mmadhye agnisthānaṃ niścitaṃ | na
+                        trayotistho vāyurādhmāpayati | te<lb n="10"/>na dyotiḥ sthānādhmānena
+                        madhyaśroto vṛddho kathaṃ sarvato vṛddhir ity āha || kraṣmaṇo sahitaścetyādi
+                        | yathā yathā |<pb n="60"/>dārayati | arddham adhas tiryak tathā tathā
+                        varddhayati | yathā krameṇa dāraṇāt yathā krameṇa varddhanam ity arthaḥ ||
+                        tad evam a<lb n="2"/>dhorddhvatiryag varddhanam ity arthaḥ | yadi sarvato
+                        varddhate |</l>
 
                     <l xml:id="NC.3.4.60">
-                        <label>NC.3.4.60</label> tatra kimastarada mātrādṛṣṭa na varddhana ity āha |
-                        dṛṣṭiś cetyā<lb n="3"/>di dhruvāṇi nityaṃ niyatamānāni |</l>
+                        <label>NC.3.4.60</label>
+                         tatra kimastarada mātrādṛṣṭa na varddhana ity āha | dṛṣṭiś cetyā<lb n="3"
+                        />di dhruvāṇi nityaṃ niyatamānāni |</l>
 
                     <l xml:id="NC.3.4.61">
-                        <label>NC.3.4.61</label> śarīravṛddhyā cāpi kasyacid avayavasya vṛddhiṃ
-                        pratipādya śarīrakṣayepi kasya<lb n="4"/> cid evābhivṛddhiṃ kṛtā iti | pṛṣṭa
-                        āha || svabhāvam iti svabhāvaṃ | prakṛtihetuṃ kṛtvā svabhāvahetutetyarthaḥ
-                        |</l>
+                        <label>NC.3.4.61</label>
+                         śarīravṛddhyā cāpi kasyacid avayavasya vṛddhiṃ pratipādya śarīrakṣayepi
+                            kasya<lb n="4"/> cid evābhivṛddhiṃ kṛtā iti | pṛṣṭa āha || svabhāvam iti
+                        svabhāvaṃ | prakṛtihetuṃ kṛtvā svabhāvahetutetyarthaḥ |</l>
 
                     <l xml:id="NC.3.4.62">
-                        <label>NC.3.4.62</label> prakriya<lb n="5"/>te janyate aānayeti prakṛtiḥ |
-                        hetusvabhāvānayor yadehakṣaye 'nayor abhivṛddhiriti prakṛtisaṃyogena anyad
-                            a<lb n="6"/>pi prākṛtaṃ darśayan āha || tisraḥ prakṛtaya ity ādi ||
-                        pratyekadoṣanimittāś catasro vakṣyaṃte | prakṛtisamasamavāya<lb n="7"
-                        />nyāyena | samudāyibhyo 'nanyasamudāya iti avirodhāt ||</l>
+                        <label>NC.3.4.62</label>
+                         prakriya<lb n="5"/>te janyate aānayeti prakṛtiḥ | hetusvabhāvānayor
+                        yadehakṣaye 'nayor abhivṛddhiriti prakṛtisaṃyogena anyad a<lb n="6"/>pi
+                        prākṛtaṃ darśayan āha || tisraḥ prakṛtaya ity ādi || pratyekadoṣanimittāś
+                        catasro vakṣyaṃte | prakṛtisamasamavāya<lb n="7"/>nyāyena | samudāyibhyo
+                        'nanyasamudāya iti avirodhāt ||</l>
 
                     <l xml:id="NC.3.4.63">
-                        <label>NC.3.4.63</label> tāsāṃ vātādibhedena lakṣaṇaṃ darśayan āha ||
-                            śukra<lb n="8"/> śoṇitasaṃyoga ity ādi || tatra svabhāvataḥ śuddhaṃ
-                        bījaṃ karmmaṇā vāsamudānugarbhaṃ niṣpādayati | anilādidoṣadu<lb n="9"/>ṣṭaṃ
-                        garbhajananāya nālam iti || śukraśoṇitaśuddhāvuktaṃ || tat katham utkaṭena
-                        doṣeṇa prakṛtir ity ucyate | na hi sa <lb n="10"/>rvam eva bījadūṣaṇaṃ |
-                        sadṛśaśaktikaṃ sakalam avayavagataṃ vā kiṃ tarhi kāraṇānāṃ
-                            saṃkhyāmanā<unclear>nu</unclear>rūpacayena nā<pb n="61"/>nāvidha balaṃ
-                        ca prasavāveṣayāṃcāvayavasakalaśarīragataṃ tatrālpaṃ sakalāṃ
-                        gamanavayavagataṃ bahu vā garbhapratibaddhā <lb n="2"/>karaṇāyanālaṃ
-                        jātyaṃdhamūkāde garbhasya darśanāt | nāvayavagatadoṣeṇa garbhapratibaṃdhaḥ |
-                        madhumehiṣu sarvāṃga<lb n="3"/>gatadoṣadūṣitadhātuṣu garbhadarśanāt | na
-                        sakala śarīragatālpadoṣeṇāpi | tad uktaṃ carake | yasya yasya hy aṃ<lb n="4"
+                        <label>NC.3.4.63</label>
+                         tāsāṃ vātādibhedena lakṣaṇaṃ darśayan āha || śukra<lb n="8"/> śoṇitasaṃyoga
+                        ity ādi || tatra svabhāvataḥ śuddhaṃ bījaṃ karmmaṇā vāsamudānugarbhaṃ
+                        niṣpādayati | anilādidoṣadu<lb n="9"/>ṣṭaṃ garbhajananāya nālam iti ||
+                        śukraśoṇitaśuddhāvuktaṃ || tat katham utkaṭena doṣeṇa prakṛtir ity ucyate |
+                        na hi sa <lb n="10"/>rvam eva bījadūṣaṇaṃ | sadṛśaśaktikaṃ sakalam
+                        avayavagataṃ vā kiṃ tarhi kāraṇānāṃ
+                        saṃkhyāmanā<unclear>nu</unclear>rūpacayena nā<pb n="61"/>nāvidha balaṃ ca
+                        prasavāveṣayāṃcāvayavasakalaśarīragataṃ tatrālpaṃ sakalāṃ gamanavayavagataṃ
+                        bahu vā garbhapratibaddhā <lb n="2"/>karaṇāyanālaṃ jātyaṃdhamūkāde garbhasya
+                        darśanāt | nāvayavagatadoṣeṇa garbhapratibaṃdhaḥ | madhumehiṣu sarvāṃga<lb
+                            n="3"/>gatadoṣadūṣitadhātuṣu garbhadarśanāt | na sakala
+                        śarīragatālpadoṣeṇāpi | tad uktaṃ carake | yasya yasya hy aṃ<lb n="4"
                         />gāvayavasya bījabhāgo duṣṭo bhavati | tasya tasyaivāṃgāvayavasyopataptiḥ |
                         tatra sakalāṃgagatān mahato doṣadū<lb n="5"/>ṣaṇād bījasya garbhāsaṃbhava
                         eva | sakalabījabhāgavātāt tu mahatodoṣāt ṣaṃḍhaṃ | śukraṃ
@@ -576,31 +599,31 @@
                         vātādijā kāye citte satvād isaṃbhavā |</l>
 
                     <l xml:id="NC.3.4.64-67">
-                        <label>NC.3.4.64-67</label> tatra vātādiprakṛter vikārā<lb n="10"/>kārayor
-                        bhedena bhinnaṃ svalakṣaṇaṃ nirddiśan āha || tatra vātaprakṛtir ity ādi |
-                        durbhago 'manoramākāramākāra: jā<pb n="62"/> garūkatvād i yo vihārāḥ
-                        sphuṭitakaracaraṇādayaḥ ākārāḥ krodhīhiṃsanaśīladaṃtanakhādīn
-                            krodhādaśana|<lb n="2"/>daśaśīla <add place="top-margin">ākṛtiriti</add>
-                        ધૃતિર્યમાત્મિકાસાdhṛtiryamātmikā sā'vidyamānā yasya sa tathā dhamanīcitaḥ
-                        dhamanīśabdaḥ sādṛśyāt sthirādiṣu varttate ||<lb n="3"/>tena
-                        śirāsnāyudhamanīcitaḥ aṭanogamanaśīlaḥ | tena kāyā navasthitiruktā ||
-                        anavasthitātmeti caṃcalamana||<lb n="4"/>anena māno 'navasthānaṃ |
-                        pralāpītyanena asaṃbaṃdhavākyaśīlatvena vacanānavasthānaṃ ca | vāyor
-                            vi<unclear>yadgā</unclear>imatvalāghavaṃ<lb n="5"/>ca latābhiḥ
+                        <label>NC.3.4.64-67</label>
+                         tatra vātādiprakṛter vikārā<lb n="10"/>kārayor bhedena bhinnaṃ svalakṣaṇaṃ
+                        nirddiśan āha || tatra vātaprakṛtir ity ādi | durbhago 'manoramākāramākāra:
+                            jā<pb n="62"/> garūkatvād i yo vihārāḥ sphuṭitakaracaraṇādayaḥ ākārāḥ
+                        krodhīhiṃsanaśīladaṃtanakhādīn krodhādaśana|<lb n="2"/>daśaśīla <add
+                            place="top-margin">ākṛtiriti</add> ધૃતિર્યમાત્મિકાસાdhṛtiryamātmikā
+                        sā'vidyamānā yasya sa tathā dhamanīcitaḥ dhamanīśabdaḥ sādṛśyāt sthirādiṣu
+                        varttate ||<lb n="3"/>tena śirāsnāyudhamanīcitaḥ aṭanogamanaśīlaḥ | tena
+                        kāyā navasthitiruktā || anavasthitātmeti caṃcalamana||<lb n="4"/>anena māno
+                        'navasthānaṃ | pralāpītyanena asaṃbaṃdhavākyaśīlatvena vacanānavasthānaṃ ca
+                        | vāyor vi<unclear>yadgā</unclear>imatvalāghavaṃ<lb n="5"/>ca latābhiḥ
                         vātaprakṛteḥ | svapne viyadgā<del>jā</del>mitvaṃ saṃbhrameṇa || tāratamyeṇa
                         avyavasthitam iti | asthitim iti | anava<lb n="6"/>sthitabuddhiniyatasya
                         caṃcalacittatvāt stokaratādisaṃcaya | kāyādyanavasthiteḥ | ajīna
                         anavasthānāt pitta<lb n="7"/>prakṛtiḥ ||</l>
 
                     <l xml:id="NC.3.4.68-71">
-                        <label>NC.3.4.68-71</label> punaḥ svedaprakṣaraṇaśīlaḥ | durgraṃdhiḥ
-                        pittasya pūtitvāt || tāmraśabdena saha nakhādayaḥ pāṇitalāṃtāḥ<lb n="8"
-                        />pratyekam abhisaṃbadhyaṃte | medhāvītyādinā cittaprakṛter dharmmaḥ |
-                        svapne vigṛhyāvaktāprāyeṇa paṭhanāt | prativaca<lb n="9"/>naśīlaḥ ||
-                        saṃbaṃdhārthakaṃ vādinānukūlaṃ vadatīti vāci prakṛtidharmaḥ || svapnepi
-                        pittadharmmabhāvitamanāḥ kaḥ kā<lb n="10"/>dīnyeva
-                        pitta<add>pīta</add>varṇānyapi paśyati | pittasya satvabahulatvāt ||
-                        bhayāsthānena praṇatiṃ gachati | apra<add place="inline">
+                        <label>NC.3.4.68-71</label>
+                         punaḥ svedaprakṣaraṇaśīlaḥ | durgraṃdhiḥ pittasya pūtitvāt || tāmraśabdena
+                        saha nakhādayaḥ pāṇitalāṃtāḥ<lb n="8"/>pratyekam abhisaṃbadhyaṃte |
+                        medhāvītyādinā cittaprakṛter dharmmaḥ | svapne vigṛhyāvaktāprāyeṇa paṭhanāt
+                        | prativaca<lb n="9"/>naśīlaḥ || saṃbaṃdhārthakaṃ vādinānukūlaṃ vadatīti
+                        vāci prakṛtidharmaḥ || svapnepi pittadharmmabhāvitamanāḥ kaḥ kā<lb n="10"
+                        />dīnyeva pitta<add>pīta</add>varṇānyapi paśyati | pittasya satvabahulatvāt
+                        || bhayāsthānena praṇatiṃ gachati | apra<add place="inline">
                             <unclear>ge</unclear></add>teṣu sāṃtvanā<pb n="63"/>dikā<add place="top"
                             >dānaśīlaḥ|1 </add><del>ma</del> vyathitāsya gati<add place="inline"
                             >riti |</add>vyathitasukhaṃ samukhaṃ pākatvāt | dhāvanakteśāsatvāt |
@@ -608,9 +631,10 @@
                         tathā ||</l>
 
                     <l xml:id="NC.3.4.72-76">
-                        <label>NC.3.4.72-76</label> śleṣmaprakṛti dūrvvādīnāma<add place="inline"
-                            >nya</add>tamavarṇaḥ || ārdramaśuṣkamariṣṭakaḥ kṛṣṇava<lb n="3"
-                        />rṇaphalaṃ | ādraśarakāṃḍamādraśara<unclear>papartha ||</unclear>subhago
+                        <label>NC.3.4.72-76</label>
+                         śleṣmaprakṛti dūrvvādīnāma<add place="inline">nya</add>tamavarṇaḥ ||
+                        ārdramaśuṣkamariṣṭakaḥ kṛṣṇava<lb n="3"/>rṇaphalaṃ |
+                            ādraśarakāṃḍamādraśara<unclear>papartha ||</unclear>subhago
                         manoramākāraḥ | ata eva priyadarśanaḥ | <unclear>su</unclear>madhurapriyaḥ |
                             a<lb n="4"/>mlādi paṃcarasapriyaḥ || śleṣmaṇo mādhuryāt | kaṭukādīni
                         kāmayate | evaṃ vātaprakṛtiravdhaṃ | pittaprakṛtimadhuraṃ ||<lb n="5"
@@ -648,14 +672,14 @@
 
 
                     <l xml:id="NC.3.4.81-87">
-                        <label>NC.3.4.81-87</label> ākāśasya vivekamahatve 'rthe guṇayogāt ||<lb
-                            n="3"/>satvād i guṇatodena tu cittaprakṛtinirddiśan āha ||
-                        śaucamāstikyam ity ādi | brahmakāyalakṣaṇaṃ | brahmasatvenotyā <lb n="4"/>di
-                        tasya kāma<add place="inline">ya</add>sya | etena satvakāyayor nnityam
-                        anyānyāvidhāyitvam uktaṃ | śauryam ity ādi | māheṃdrakāyalakṣaṇaṃ <lb n="5"
-                        />sahiṣṇutety ādi vāruṇakāyalakṣaṇaṃ | madhyastham ity ādi
-                        kauverakāyalakṣaṇaṃ | mahac ca prabhavaśaktiḥ prajo|<lb n="6"
-                        />tyānasāmarthyā || kuverasatvānaṃtaraṃ yāmyasatve vaktavye
+                        <label>NC.3.4.81-87</label>
+                         ākāśasya vivekamahatve 'rthe guṇayogāt ||<lb n="3"/>satvād i guṇatodena tu
+                        cittaprakṛtinirddiśan āha || śaucamāstikyam ity ādi | brahmakāyalakṣaṇaṃ |
+                        brahmasatvenotyā <lb n="4"/>di tasya kāma<add place="inline">ya</add>sya |
+                        etena satvakāyayor nnityam anyānyāvidhāyitvam uktaṃ | śauryam ity ādi |
+                        māheṃdrakāyalakṣaṇaṃ <lb n="5"/>sahiṣṇutety ādi vāruṇakāyalakṣaṇaṃ |
+                        madhyastham ity ādi kauverakāyalakṣaṇaṃ | mahac ca prabhavaśaktiḥ prajo|<lb
+                            n="6"/>tyānasāmarthyā || kuverasatvānaṃtaraṃ yāmyasatve vaktavye
                         gaṃdharvasatvābhidhānaṃ | gaṃdharvasatvaṃ yakṣasadṛśaṃ yakṣasa<lb n="7"
                         />tvadyotanārthaṃ | prāptakārītyādinā yāmyaṃ satvaṃ brahmacaryam ity ādinā
                         ṛṣisatvaṃ | evaṃ brāhmyamāheṃdravāruṇā<lb n="8"
@@ -664,12 +688,12 @@
 
 
                     <l xml:id="NC.3.4.88-93">
-                        <label>NC.3.4.88-93</label> teṣv api brāhmyaṃ śuddhatamaṃ | aiśva<lb n="9"
-                        />ryavaṃtam ity ādi || āsuraṃ satvaṃ raudraṃ tīkṣṇaṃ | astīyakaṃ guṇeṣu
-                        matsaraṃ | eṣadhikaṃṭhabharaṃ | ekāṃtagrāhitetyā<lb n="10"/>di rākṣasaṃ
-                        satvalakṣaṇaṃ | ekāṃtagrāhitā niyamena gṛhītā yogaśīlatāḥ | utsṛṣṭā
-                            hāraśīlatetyādināpi<pb n="66"/>satvaṃ |
-                        <unclear>utsiṣṭā</unclear>hāraśīlatā | <unclear>utsiṣṭāhārācāriṇo bhāvaḥ
+                        <label>NC.3.4.88-93</label>
+                         teṣv api brāhmyaṃ śuddhatamaṃ | aiśva<lb n="9"/>ryavaṃtam ity ādi || āsuraṃ
+                        satvaṃ raudraṃ tīkṣṇaṃ | astīyakaṃ guṇeṣu matsaraṃ | eṣadhikaṃṭhabharaṃ |
+                            ekāṃtagrāhitetyā<lb n="10"/>di rākṣasaṃ satvalakṣaṇaṃ | ekāṃtagrāhitā
+                        niyamena gṛhītā yogaśīlatāḥ | utsṛṣṭā hāraśīlatetyādināpi<pb n="66"/>satvaṃ
+                        | <unclear>utsiṣṭā</unclear>hāraśīlatā | <unclear>utsiṣṭāhārācāriṇo bhāvaḥ
                             ||</unclear>હારાચારિણો āvokṣasāhasapriyatā || apacitaprītiḥ<lb n="2"
                         />ભાવsāhasaprītiś cātīkṣṇam ity ādināpi sarpyasatvaṃ || krodhe sati satvena
                         lakṣitaṃ | akrodhetīsaṃ | tad uktaṃ cara<lb n="3"/>ke || akruddhaṃ śūraṃ
@@ -678,18 +702,18 @@
 
 
                     <l xml:id="NC.3.4.94-99">
-                        <label>NC.3.4.94-99</label> durmmedhastvaṃ ity ādinā paśusatvaṃ |
-                        anavasthitetyādinā matsyasatvaṃ | satvabudhyaṃgahī netyādinā vṛkṣa<lb n="5"
-                        />satvaṃ | satvabudhyaṃgahīnābhyāṃ hīnaṃ sthiraṃ ekasthānasthaṃ | ete trayas
-                        tamo bahulāḥ satvabhedāḥ | eṣāṃ sthāne ciki<lb n="6"/>tsopayogitvaṃ darśayan
-                        āha | vijñāyakāyavikṛtiriti | anurūpām ucitāṃ | tad uktaṃ bhūtavidyāyāṃ | na
-                            vā|<lb n="7"/>caukṣyaṃ prayuṃjīta prayogaṃ devatāgṛhe | evamādy anyad
-                        api anuvarttavyāṃ dhātraparīkṣāyām api prayojanaṃ ||<lb n="8"/> tad uktaṃ
-                        kāśyapena | yo yathā satvaḥ kumāraḥ <del>sya</del><add place="below-margin"
-                            >syātta</add>thā satvām evāsya dhātrīm upasthāpayet | kiṃ kāraṇaṃ tad
-                            vipāyā<lb n="9"/>nirdhāraṇaṃ bhavati tad uktaṃ | tatraiva |
-                        piśācasatvānānāryo kumāraḥ samudīkṣitanirvāṇām eva cāpnoti | tathā rā<lb
-                            n="10"/> kṣasasatvā ity ādi || </l>
+                        <label>NC.3.4.94-99</label>
+                         durmmedhastvaṃ ity ādinā paśusatvaṃ | anavasthitetyādinā matsyasatvaṃ |
+                        satvabudhyaṃgahī netyādinā vṛkṣa<lb n="5"/>satvaṃ | satvabudhyaṃgahīnābhyāṃ
+                        hīnaṃ sthiraṃ ekasthānasthaṃ | ete trayas tamo bahulāḥ satvabhedāḥ | eṣāṃ
+                        sthāne ciki<lb n="6"/>tsopayogitvaṃ darśayan āha | vijñāyakāyavikṛtiriti |
+                        anurūpām ucitāṃ | tad uktaṃ bhūtavidyāyāṃ | na vā|<lb n="7"/>caukṣyaṃ
+                        prayuṃjīta prayogaṃ devatāgṛhe | evamādy anyad api anuvarttavyāṃ
+                        dhātraparīkṣāyām api prayojanaṃ ||<lb n="8"/> tad uktaṃ kāśyapena | yo yathā
+                        satvaḥ kumāraḥ <del>sya</del><add place="below-margin">syātta</add>thā
+                        satvām evāsya dhātrīm upasthāpayet | kiṃ kāraṇaṃ tad vipāyā<lb n="9"
+                        />nirdhāraṇaṃ bhavati tad uktaṃ | tatraiva | piśācasatvānānāryo kumāraḥ
+                        samudīkṣitanirvāṇām eva cāpnoti | tathā rā<lb n="10"/> kṣasasatvā ity ādi || </l>
 
                     <trailer>iti śauśrute śārīre nyāyacaṃdrikāyāṃ paṃjikāyāṃ garbhavyākaraṇaṃ <add
                             place="inline">||</add></trailer>

--- a/gayadasa/provisional-edition_nyayacandrika_sarirasthana.txt
+++ b/gayadasa/provisional-edition_nyayacandrika_sarirasthana.txt
@@ -118,6 +118,8 @@
 
         <revisionDesc>
             <change when="2026-08-05" who="Andrey Klebanov"> Began this file. </change>
+            <change when="2025-08-11" who="Andrey Klebanov">Provisional edition of 3.4.1 + beginning
+                of 3.4.2</change>
         </revisionDesc>
     </teiHeader>
 
@@ -129,16 +131,37 @@
                 <div n="4" type="adhyāya">
 
                     <div xml:id="NC.3.4.1" type="commentary-unit" style="stream1">
-
-                        <p xml:id="NC.3.4.1a"> garbhāvakrāntiśārīrānantaraṃ
-                            garbhavyākaraṇasyocitatvād vyākaraṇaṃ vivaraṇaṃ | tat śukraśoṇitaṃ
-                            garbhāśayagataṃ prāṇīnāṃ garbhaḥ|| </p>
-
+                        <lg xml:id="NC.3.4.1a" type="prose">
+                            <l>garbhāvakrāntiśārīrānantaraṃ garbhavyākaraṇasyocitatvād
+                                garbhavyākaraṇaśārīrārambhaḥ | vyākaraṇaṃ vivaraṇaṃ |<anchor
+                                    xml:id="NC.3.4.1a-n1"/>
+                                <sic>tat</sic> śukraśoṇitaṃ garbhāśayagataṃ prāṇīnāṃ garbhaḥ
+                                    ||<anchor xml:id="NC.3.4.1a-n2"/></l>
+                        </lg>
+                    </div>
+                    <div xml:id="NC.3.4.3" type="commentary-unit" style="stream1">
+                        <lg xml:id="NC.3.4.3a" type="prose">
+                            <l><sic>tacca prāṇa/ na yeṣām eva bhāvānām anvayavyatirekābhyāṃ
+                                    anvayavyatireki ca teṣv eva prīṇābhyāṃ paribhāṣayann āha</sic> –
+                                agnīṣoma ity ādi ||</l>
+                        </lg>
                     </div>
                 </div>
             </div>
         </body>
     </text>
-
-
+    <standOff corresp="#NC.3.4.1a" type="Emendation">
+        <note target="#NC.3.4.1a-n1" xml:lang="en">The compound <foreign xml:lang="sa"
+                >garbhavyākaraṇaśārīrārambhaḥ</foreign> is supplied conjecturally, based on the
+            corresponding opening formulae of the other chapters in the manuscript. Its omission may
+            have resulted from an eye-skip prompted by the repetition of the string "<foreign
+                xml:lang="sa">vyākaraṇa</foreign>".</note>
+    </standOff>
+    <standOff corresp="#NC.3.4.1a" type="Note">
+        <note target="#NC.3.4.1a-n2" xml:lang="en">This definition of the term <foreign
+                xml:lang="sa">garbha</foreign> likely aludes to <title>Suśrutasaṃhitā</title> 3.5.3
+            (according to the vulgate text <ref target="#A">A</ref>): <foreign xml:lang="sa"
+                >śukraśoṇitaṃ garbhāśayastham ātmaprakṛtivikārasaṃmūrcchitaṃ garbha ity ucyate
+                |</foreign></note>
+    </standOff>
 </TEI>

--- a/gayadasa/provisional-edition_nyayacandrika_sarirasthana.txt
+++ b/gayadasa/provisional-edition_nyayacandrika_sarirasthana.txt
@@ -61,31 +61,58 @@
             <sourceDesc>
                 <msDesc xml:id="Sanskrit" xml:lang="en">
                     <msIdentifier>
-                        <idno type="siglum">NE</idno>
+                        <idno type="siglum">NC</idno>
                     </msIdentifier>
                 </msDesc>
 
                 <listWit>
-                    <witness xml:id="A">The <title>Nibandhasaṅgraha</title> by Ḍalhaṇācārya, <abbr
-                            type="siglum">A</abbr>
-                        <bibl>
-                            <title>Suśrutasamhitā of Suśruta with the Nibandhasaṅgraha Commentary of
-                                Śrī Ḍalhanāchārya and the Nyāyacandrikā Pañjikā of Śrī
-                                Gayadāsāchārya on Nidānasthāna, edited from the begining to the 9th
-                                ādhyāya of Cikitsāsthāna by Vaidya Jādavji Trikamji Āchārya and the
-                                rest by Nārāyaṇ Rām Āchārya</title>
-                            <editor role="sections:1.1-4.9">Yādavaśarman Trivikramātmaja
-                                Ācāryā</editor>
-                            <editor role="sections:4.10-6.66">Nārāyaṇ Rām Āchārya</editor>
-                            <publisher>Nirṇaya Sāgar Press</publisher>
-                            <pubPlace>Bombay</pubPlace>
-                            <date>1938</date>
-                            <edition>Revised third edition</edition>
-                            <edition>Reprint edition Varanasi/Delhi: Chaukhambha Orientalia,
-                                1992|</edition>
-                        </bibl>
-                    </witness>
+                    <witness xml:id="A" source="#susruta-vulgate"> The text of the
+                            <title>Suśrutasaṃhitā</title> in the 1938 vulgate edition, <abbr
+                            type="siglum">A</abbr>. </witness>
+
+                    <witness xml:id="NS" source="#susruta-vulgate"> The text of the
+                            <title>Nibandhasaṅgraha</title> by <persName>Ḍalhaṇācārya</persName> in
+                        the 1938 vulgate edition, <abbr type="siglum">NS</abbr>. </witness>
+
+                    <witness xml:id="CS" source="#caraka-vulgate"> The text of the
+                            <title>Carakasaṃhitā</title> in the vulgate edition, <abbr type="siglum"
+                            >CS</abbr>. </witness>
+
+                    <witness xml:id="AD" source="#caraka-vulgate"> The text of the
+                            <title>Āyurvedadīpikā</title> by <persName>Cakrapāṇidatta</persName> in
+                        the vulgate edition, <abbr type="siglum">ĀD</abbr>. </witness>
                 </listWit>
+                <listBibl>
+                    <bibl xml:id="susruta-vulgate">
+                        <title>Suśrutasamhitā of Suśruta with the Nibandhasaṅgraha Commentary of Śrī
+                            Ḍalhanāchārya and the Nyāyacandrikā Pañjikā of Śrī Gayadāsāchārya on
+                            Nidānasthāna, edited from the begining to the 9th ādhyāya of
+                            Cikitsāsthāna by Vaidya Jādavji Trikamji Āchārya and the rest by Nārāyaṇ
+                            Rām Āchārya</title>
+                        <editor role="sections:1.1-4.9">Yādavaśarman Trivikramātmaja Ācāryā</editor>
+                        <editor role="sections:4.10-6.66">Nārāyaṇ Rām Āchārya</editor>
+                        <publisher>Nirṇaya Sāgar Press</publisher>
+                        <pubPlace>Bombay</pubPlace>
+                        <date>1938</date>
+                        <edition>Revised third edition</edition>
+                        <edition>Reprint edition Varanasi/Delhi: Chaukhambha Orientalia,
+                            1992|</edition>
+                    </bibl>
+
+                    <bibl xml:id="caraka-vulgate">
+                        <title>Carakasaṃhitā, śrīcakrapāṇidattaviracitayā āyurvedadīpikāvyākhyayā
+                            saṃvalitā = The Charakasaṃhitā of Agniveśa revised by Charaka and
+                            Dṛiḍhabala With the Āyurveda-dīpikā Commentary of
+                            Chakrapāṇidatta</title>
+                        <editor>Yādavaśarman Trivikramātmaja Ācārya</editor>
+                        <publisher>Śa. He. Gurjara at the Āyurvidyā Mudraṇālaya</publisher>
+                        <pubPlace>Puṇyapattane</pubPlace>
+                        <date>1981</date>
+                        <note>3rd. ed. Nirnaya Sagar Press, Bombay, 1941, 4th. ed. Munshiram
+                            Manoharlal, New Delhi, 1981.</note>
+                    </bibl>
+                </listBibl>
+
             </sourceDesc>
         </fileDesc>
 
@@ -94,9 +121,6 @@
         </revisionDesc>
     </teiHeader>
 
-    <!-- The provisional edition of Gayadāsa’s commentary on the
-         Śārīrasthāna will follow in the text element. -->
-
     <text xml:lang="sa-Latn-t-sa-Deva">
 
         <body>
@@ -104,10 +128,13 @@
 
                 <div n="4" type="adhyāya">
 
+                    <div xml:id="NC.3.4.1" type="commentary-unit" style="stream1">
 
-                    <p xml:id="NC.3.4.1"> garbhāvakrāntiśārīrānantaraṃ garbhavyākaraṇasyocitatvāt
-                        vyākaraṇaṃ vivaraṇaṃ | tat śukraśoṇitaṃ garbhāśayagataṃ prāṇīnāṃ garbhaḥ||
-                    </p>
+                        <p xml:id="NC.3.4.1a"> garbhāvakrāntiśārīrānantaraṃ
+                            garbhavyākaraṇasyocitatvād vyākaraṇaṃ vivaraṇaṃ | tat śukraśoṇitaṃ
+                            garbhāśayagataṃ prāṇīnāṃ garbhaḥ|| </p>
+
+                    </div>
                 </div>
             </div>
         </body>


### PR DESCRIPTION
Dear @wujastyk,

This is my work from last week and today. I realize that it is better to submit changes incrementally, but I did not want to send anything entirely experimental, especially since I assumed that no one else was working on the same files.

The work has two main strands:

- **Transcription:** I proofread further sections. The file probably still contains a mixture of the Saktumiva 2 structure you asked me to follow—`<lg><l>…</l></lg>`—and the older use of `<l>` alone. I will update these passages as I proceed with the edition, since the `xml:id`s will require considerable adjustment in any case.

- **Provisional edition:** Although there is not much new text in the file, I have spent quite some time experimenting with its structure. I see two respects in which editing the Nyāyacandrikā may diverge from the usual Suśruta Project workflow:

1. Unlike with the NE, there will likely be (many?) passages for which we cannot immediately recover a plausible text or propose a convincing emendation. We therefore need a way to signal apparently corrupt passages in the provisional edition. In a printed critical edition, I would mark these with a dagger and, where necessary, add a note. I am not sure whether you want to introduce an equivalent visual marker here. For the moment, I have experimented with enclosing such passages in `<sic>…</sic>`, although I am unsure whether this is the appropriate project convention. This is something we need to consider.

2. The structure of the NC is inherently more complex than that of the SS. A single commentarial unit formally corresponding to, say, SS 3.4.3 may contain several kinds of text: prose discussions, quotations, verses, and so forth. It does not seem sensible to place all of this inside a single `<lg><l>…</l></lg>` unit. After considering several possibilities, I currently propose using a container such as `<div xml:id="NC.3.4.3" type="commentary-unit" style="stream1">`, containing several `<lg><l>…</l></lg>` units with individual `xml:id`s such as `NC.3.4.3a`, `NC.3.4.3b`, etc.

Please have a look and let me know what you think of these proposals.